### PR TITLE
Convert Bach works table to JSON

### DIFF
--- a/bach_works.json
+++ b/bach_works.json
@@ -1,0 +1,15672 @@
+[
+  {
+    "BWV": "0001",
+    "BC": "A173",
+    "Title": "Wie schön leuchtet der Morgenstern",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0002",
+    "BC": "A098",
+    "Title": "Ach Gott, vom Himmel sieh darein",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0003",
+    "BC": "A033",
+    "Title": "Ach Gott, wie manches Herzeleid",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0004",
+    "BC": "A054",
+    "Title": "Christ lag in Todesbanden",
+    "Forces": "4vv ch orch",
+    "Key": "E minor",
+    "Date": "1707–08?, rev. 1724–25",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0005",
+    "BC": "A145",
+    "Title": "Wo soll ich fliehen hin",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0006",
+    "BC": "A057",
+    "Title": "Bleib bei uns, denn es will Abend werden",
+    "Forces": "4vv ch orch",
+    "Key": "C minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "movt.III adapted in BWV 649"
+  },
+  {
+    "BWV": "0007",
+    "BC": "A177",
+    "Title": "Christ unser Herr zum Jordan kam",
+    "Forces": "3vv ch orch",
+    "Key": "E minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0008",
+    "BC": "A137",
+    "Title": "Liebster Gott, wenn werd ich sterben?",
+    "Forces": "4vv ch orch",
+    "Key": "E major",
+    "Date": "1724, rev. 1744–47",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0009",
+    "BC": "A107",
+    "Title": "Es ist das Heil uns kommen her",
+    "Forces": "4vv ch orch",
+    "Key": "E major",
+    "Date": "1732–35",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0010",
+    "BC": "A175",
+    "Title": "Meine Seel erhebt den Herren",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "movt.V adapted in BWV 648"
+  },
+  {
+    "BWV": "0011",
+    "BC": "D09",
+    "Title": "Lobet Gott in seinen Reichen(Himmelfahrts-Oratorium)",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1735",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 233"
+  },
+  {
+    "BWV": "0012",
+    "BC": "A068",
+    "Title": "Weinen, Klagen, Sorgen, Zagen",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0013",
+    "BC": "A034",
+    "Title": "Meine Seufzer, meine Tränen",
+    "Forces": "4vv ch orch",
+    "Key": "D minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0014",
+    "BC": "A040",
+    "Title": "WarWär Gott nicht mit uns diese Zeit",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1735",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0015",
+    "BC": "V01",
+    "Title": "Denn du wirst meine Seele nicht in der Hölle lassen",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Ludwig Bach"
+  },
+  {
+    "BWV": "0016",
+    "BC": "A023",
+    "Title": "Herr Gott, dich loben wir",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0017",
+    "BC": "A131",
+    "Title": "Wer Dank opfert, der preiset mich",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 236"
+  },
+  {
+    "BWV": "0018",
+    "BC": "A044",
+    "Title": "Gleichwie der Regen und Schnee vom Himmel fällt",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1713–14, rev. 1724",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 233"
+  },
+  {
+    "BWV": "0019",
+    "BC": "A180",
+    "Title": "Es erhub sich ein Streit",
+    "Forces": "3vv ch orch",
+    "Key": "C major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0020",
+    "BC": "A095",
+    "Title": "O Ewigkeit, du Donnerwort",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0021",
+    "BC": "A099",
+    "Title": "Ich hatte viel Bekümmernis",
+    "Forces": "3vv ch orch",
+    "Key": "C minor",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0022",
+    "BC": "A048",
+    "Title": "Jesus nahm zu sich die Zwölfe",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0023",
+    "BC": "A047",
+    "Title": "Du wahrer Gott und Davids Sohn",
+    "Forces": "3vv ch orch",
+    "Key": "C minor",
+    "Date": "1723, rev. 1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0024",
+    "BC": "A102",
+    "Title": "Ein ungefärbt Gemüte",
+    "Forces": "4vv ch orch",
+    "Key": "F major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0025",
+    "BC": "A129",
+    "Title": "Es ist nichts Gesundes an meinem Leibe",
+    "Forces": "3vv ch orch",
+    "Key": "E minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0026",
+    "BC": "A162",
+    "Title": "Ach wie flüchtig, ach wie nichtig",
+    "Forces": "4vv ch orch",
+    "Key": "A minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0027",
+    "BC": "A138",
+    "Title": "Wer weiss, wie nahe mir mein Ende",
+    "Forces": "4vv ch orch",
+    "Key": "C minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0028",
+    "BC": "A020",
+    "Title": "Gottlob! nun geht das Jahr zu Ende",
+    "Forces": "4vv ch orch",
+    "Key": "A minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "theme used in BWV 231"
+  },
+  {
+    "BWV": "0029",
+    "BC": "B08",
+    "Title": "Wir danken dir, Gott, wir danken dir",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "Sinfonia (No. 1) based on the Prelude (No. 1) of the Violin Partita No. 3 BWV 1006."
+  },
+  {
+    "BWV": "0030",
+    "BC": "A178",
+    "Title": "Freue dich, erlöste Schar",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1738",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0030a",
+    "BC": "G31",
+    "Title": "Angenehmes Wiederau",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1737",
+    "Genre": "Vocal",
+    "Notes": "dramma per musica"
+  },
+  {
+    "BWV": "0031",
+    "BC": "A055",
+    "Title": "Der Himmel lacht! die Erde jubiliert",
+    "Forces": "3vv ch orch",
+    "Key": "C major",
+    "Date": "1715, rev. 1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0032",
+    "BC": "A031",
+    "Title": "Liebster Jesu, mein Verlangen",
+    "Forces": "2vv ch orch",
+    "Key": "E minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0033",
+    "BC": "A127",
+    "Title": "Allein zu dir, Herr Jesu Christ",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0034",
+    "BC": "A084",
+    "Title": "O ewiges Feuer, o Ursprung der Liebe",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1746–47",
+    "Genre": "Vocal",
+    "Notes": "adapted from BWV 34a"
+  },
+  {
+    "BWV": "0034a",
+    "BC": "B13",
+    "Title": "O ewiges Feuer, o Ursprung der Liebe",
+    "Forces": "4vv ch (orch?)",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly lost; rev. as BWV 34"
+  },
+  {
+    "BWV": "0035",
+    "BC": "A125",
+    "Title": "Geist und Seele wird verwirret",
+    "Forces": "v orch",
+    "Key": "D minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly based on a lost oboe concerto (see BWV 1059R)"
+  },
+  {
+    "BWV": "0036",
+    "BC": "A003",
+    "Title": "Schwingt freudig euch empor",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1725–30?, rev. 1731",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 36c"
+  },
+  {
+    "BWV": "0036a",
+    "BC": "G12",
+    "Title": "Steigt freudig in die Luft",
+    "Forces": "",
+    "Key": "",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "based on BWV.36c; lost"
+  },
+  {
+    "BWV": "0036b",
+    "BC": "G38",
+    "Title": "Die Freude reget sich",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1735",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0036c",
+    "BC": "G35",
+    "Title": "Schwingt freudig euch empor",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "rev. as BWV.36"
+  },
+  {
+    "BWV": "0037",
+    "BC": "A075",
+    "Title": "Wer da glaubet und getauft wird",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0038",
+    "BC": "A152",
+    "Title": "Aus tiefer Not schrei ich zu dir",
+    "Forces": "4vv ch orch",
+    "Key": "E minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0039",
+    "BC": "A096",
+    "Title": "Brich dem Hungrigen dein Brot",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0040",
+    "BC": "A012",
+    "Title": "Dazu ist erschienen der Sohn Gottes",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 233"
+  },
+  {
+    "BWV": "0041",
+    "BC": "A022",
+    "Title": "Jesu, nun sei gepreiset",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0042",
+    "BC": "A063",
+    "Title": "Am Abend aber desselbigen Sabbats",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0043",
+    "BC": "A077",
+    "Title": "Gott fähret auf mit Jauchzen",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0044",
+    "BC": "A078",
+    "Title": "Sie werden euch in den Bann tun",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0045",
+    "BC": "A113",
+    "Title": "Es ist dir gesagt, Mensch, was gut ist",
+    "Forces": "4vv ch orch",
+    "Key": "E major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0046",
+    "BC": "A117",
+    "Title": "Schauet doch und sehet",
+    "Forces": "3vv ch orch",
+    "Key": "D minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0047",
+    "BC": "A141",
+    "Title": "Wer sich selbst erhöhet",
+    "Forces": "2vv ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0048",
+    "BC": "A144",
+    "Title": "Ich elender Mensch, wer wird mich erlösen",
+    "Forces": "2vv ch orch",
+    "Key": "G minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0049",
+    "BC": "A150",
+    "Title": "Ich geh' und suche mit Verlangen",
+    "Forces": "2vv orch",
+    "Key": "E major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "sinfonia based on a lost oboe concerto (see BWV 1053R)"
+  },
+  {
+    "BWV": "0050",
+    "BC": "A194",
+    "Title": "Nun ist das Heil und die Kraft",
+    "Forces": "2ch orch",
+    "Key": "D major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0051",
+    "BC": "A134",
+    "Title": "Jauchzet Gott in allen Landen",
+    "Forces": "v tpt str bc",
+    "Key": "C major",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0052",
+    "BC": "A160",
+    "Title": "Falsche Welt, dir trau ich nicht",
+    "Forces": "v ch orch",
+    "Key": "F major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0053",
+    "BC": "V02",
+    "Title": "Schlage doch, gewünschte Stunde",
+    "Forces": "v perc org str",
+    "Key": "E major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byMelchior Hoffmann"
+  },
+  {
+    "BWV": "0054",
+    "BC": "A051",
+    "Title": "Widerstehe doch der Sünde",
+    "Forces": "v str bc",
+    "Key": "E♭major",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": "partly rev. in BWV 247"
+  },
+  {
+    "BWV": "0055",
+    "BC": "A157",
+    "Title": "Ich armer Mensch, ich Sündenknecht",
+    "Forces": "v ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0056",
+    "BC": "A146",
+    "Title": "Ich will den Kreuzstab gerne tragen",
+    "Forces": "v ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0057",
+    "BC": "A014",
+    "Title": "Selig ist der Mann",
+    "Forces": "2vv ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0058",
+    "BC": "A026",
+    "Title": "Ach Gott, wie manches Herzeleid",
+    "Forces": "2vv orch",
+    "Key": "C major",
+    "Date": "1727, rev. 1733–34?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0059",
+    "BC": "A082",
+    "Title": "Wer mich liebet, der wird mein Wort halten",
+    "Forces": "2vv ch orch",
+    "Key": "C major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "re-used in BWV 74"
+  },
+  {
+    "BWV": "0060",
+    "BC": "A161",
+    "Title": "O Ewigkeit, du Donnerwort(Dialogue zwischen Furcht und Hoffnung)",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0061",
+    "BC": "A001",
+    "Title": "Nun komm, der Heiden Heiland",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0062",
+    "BC": "A002",
+    "Title": "Nun komm, der Heiden Heiland",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0063",
+    "BC": "A008",
+    "Title": "Christen, ätzet diesen Tag",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1714–15, rev. 1729?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0064",
+    "BC": "A015",
+    "Title": "Sehet, welch eine Liebe",
+    "Forces": "3vv ch orch",
+    "Key": "E minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0065",
+    "BC": "A027",
+    "Title": "Sie werden aus Saba alle kommen",
+    "Forces": "2vv ch orch",
+    "Key": "C major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0066",
+    "BC": "A056",
+    "Title": "Erfreut euch, ihr Herzen",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 66a"
+  },
+  {
+    "BWV": "0066a",
+    "BC": "G004",
+    "Title": "Der Himmel dacht auf Anhalts Ruhm und Glück",
+    "Forces": "2vv ch orch",
+    "Key": "",
+    "Date": "1718",
+    "Genre": "Vocal",
+    "Notes": "lost; rev. as BWV 66"
+  },
+  {
+    "BWV": "0067",
+    "BC": "A062",
+    "Title": "Halt im Gedächtnis Jesum Christ",
+    "Forces": "3vv ch orch",
+    "Key": "A major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 234"
+  },
+  {
+    "BWV": "0068",
+    "BC": "A086",
+    "Title": "Also hat Gott die Welt geliebt",
+    "Forces": "2vv ch orch",
+    "Key": "D minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0069",
+    "BC": "B10",
+    "Title": "Lobe den Herrn, meine Seele",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1742–48",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 69a"
+  },
+  {
+    "BWV": "0069a",
+    "BC": "A123",
+    "Title": "Lobe den Herrn, meine Seele",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "rev. as BWV 69"
+  },
+  {
+    "BWV": "0070",
+    "BC": "A165",
+    "Title": "Wachet, betet, seid bereit allezeit!",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 70a"
+  },
+  {
+    "BWV": "0070a",
+    "BC": "A004",
+    "Title": "Wachet, betet, seid bereit allezeit!",
+    "Forces": "",
+    "Key": "C major",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": "text not lost, but music survives in a few individual parts; rev. as BWV 70"
+  },
+  {
+    "BWV": "0071",
+    "BC": "B01",
+    "Title": "Gott ist mein König",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1708",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0072",
+    "BC": "A037",
+    "Title": "Alles nur nach Gottes Willen",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 235"
+  },
+  {
+    "BWV": "0073",
+    "BC": "A035",
+    "Title": "Herr, wie du willt, so schick's mit mir",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1724, rev. 1730–39?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0074",
+    "BC": "A083",
+    "Title": "Wer mich liebet, der wird mein Wort halten",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 59"
+  },
+  {
+    "BWV": "0075",
+    "BC": "A094",
+    "Title": "Die Elenden sollen essen",
+    "Forces": "4vv ch orch",
+    "Key": "E minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0076/1",
+    "BC": "A097",
+    "Title": "Die Himmel erzählen die Ehre Gottes",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "1st version"
+  },
+  {
+    "BWV": "0076/2",
+    "BC": "A185",
+    "Title": "Die Himmel erzählen die Ehre Gottes",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "2nd version; partly re-used in BWV 528"
+  },
+  {
+    "BWV": "0077",
+    "BC": "A126",
+    "Title": "Du sollt Gott, deinen Herren, lieben",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0078",
+    "BC": "A130",
+    "Title": "Jesu, der du meine Seele",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0079",
+    "BC": "A184",
+    "Title": "Gott der Herr ist Sonn und Schild",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 234, BWV 236"
+  },
+  {
+    "BWV": "0080",
+    "BC": "A183",
+    "Title": "Ein feste Burg ist unser Gott",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1727–31, rev. 1744–47?",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 80a, 80b; 1st version"
+  },
+  {
+    "BWV": "0080a",
+    "BC": "A052",
+    "Title": "Alles, was von Gott geboren",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": "lost; rev. in BWV 80"
+  },
+  {
+    "BWV": "0080b",
+    "BC": "A183",
+    "Title": "Ein feste Burg ist unser Gott",
+    "Forces": "",
+    "Key": "",
+    "Date": "1715",
+    "Genre": "Vocal",
+    "Notes": "fragment only; rev. in BWV 80"
+  },
+  {
+    "BWV": "0081",
+    "BC": "A039",
+    "Title": "Jesus schläft, was soll ich hoffen?",
+    "Forces": "3vv ch orch",
+    "Key": "E minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0082",
+    "BC": "A169",
+    "Title": "Ich habe genug",
+    "Forces": "v ob str bc",
+    "Key": "C minor",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0083",
+    "BC": "A167",
+    "Title": "Erfreute Zeit im neuen Bunde",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0084",
+    "BC": "A043",
+    "Title": "Ich bin vergnügt mit meinem Glücke",
+    "Forces": "v ch orch",
+    "Key": "E minor",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0085",
+    "BC": "A066",
+    "Title": "Ich bin ein guter Hirt",
+    "Forces": "4vv ch orch",
+    "Key": "C minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0086",
+    "BC": "A073",
+    "Title": "Wahrlich, wahrlich, ich sage euch",
+    "Forces": "4vv ch orch",
+    "Key": "E major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0087",
+    "BC": "A074",
+    "Title": "Bisher habt ihr nichts gebeten in meinem Namen",
+    "Forces": "3vv ch orch",
+    "Key": "D minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0088",
+    "BC": "A105",
+    "Title": "Siehe, ich will viel Fischer aussenden",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0089",
+    "BC": "A155",
+    "Title": "Was soll ich aus dir machen, Ephraim",
+    "Forces": "3vv ch orch",
+    "Key": "C minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0090",
+    "BC": "A163",
+    "Title": "Es reißet euch ein schrecklich Ende",
+    "Forces": "3vv ch orch",
+    "Key": "D minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0091",
+    "BC": "A009",
+    "Title": "Gelobet seist du, Jesu Christ",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0092",
+    "BC": "A042",
+    "Title": "Ich hab in Gottes Herz und Sinn",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0093",
+    "BC": "A104",
+    "Title": "Wer nur den lieben Gott lässt walten",
+    "Forces": "4vv ch 2ob str bc",
+    "Key": "C minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "movt.IV adapted in BWV 647"
+  },
+  {
+    "BWV": "0094",
+    "BC": "A115",
+    "Title": "Was frag ich nach der Welt",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0095",
+    "BC": "A136",
+    "Title": "Christus, der ist mein Leben",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0096",
+    "BC": "A142",
+    "Title": "Herr Christ, der einge Gottessohn",
+    "Forces": "4vv ch orch",
+    "Key": "F major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0097",
+    "BC": "A189",
+    "Title": "In allen meinen Taten",
+    "Forces": "4vv ch orch",
+    "Key": "B♭major",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0098",
+    "BC": "A153",
+    "Title": "Was Gott tut, das ist Wohlgethan",
+    "Forces": "4vv ch orch",
+    "Key": "B♭major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0099",
+    "BC": "A133",
+    "Title": "Was Gott tut, das ist wohlgetan",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0100",
+    "BC": "A191",
+    "Title": "Was Gott tut, das ist wohlgetan",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1732–35",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0101",
+    "BC": "A118",
+    "Title": "Nimm von uns, Herr, du treuer Gott",
+    "Forces": "4vv ch orch",
+    "Key": "D minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0102",
+    "BC": "A119",
+    "Title": "Herr, deine Augen sehen nach dem Glauben",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 233, BWV 235"
+  },
+  {
+    "BWV": "0103",
+    "BC": "A069",
+    "Title": "Ihr werdet weinen und heulen",
+    "Forces": "2vv ch orch",
+    "Key": "B minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0104",
+    "BC": "A065",
+    "Title": "Du Hirte Israel, höre",
+    "Forces": "2vv ch orch",
+    "Key": "G major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0105",
+    "BC": "A114",
+    "Title": "Herr, gehe nicht ins Gericht mit deinem Knecht",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0106",
+    "BC": "B18",
+    "Title": "Gottes Zeit ist die allerbeste Zeit(Actus Tragicus)",
+    "Forces": "2vv ch orch",
+    "Key": "E♭major",
+    "Date": "1707–08?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0107",
+    "BC": "A109",
+    "Title": "Was willst du dich betrüben",
+    "Forces": "3vv ch orch",
+    "Key": "B minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0108",
+    "BC": "A072",
+    "Title": "Es ist euch gut, daß ich hingehe",
+    "Forces": "3vv ch orch",
+    "Key": "A major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0109",
+    "BC": "A151",
+    "Title": "Ich glaube, lieber Herr",
+    "Forces": "2vv ch orch",
+    "Key": "D minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0110",
+    "BC": "A010",
+    "Title": "Unser Mund sei voll Lachens",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0111",
+    "BC": "A036",
+    "Title": "Was mein Gott will, das g'scheh allzeit",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0112",
+    "BC": "A067",
+    "Title": "Der Herr ist mein getreuer Hirt",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0113",
+    "BC": "A122",
+    "Title": "Herr Jesu Christ, du höchstes Gut",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0114",
+    "BC": "A139",
+    "Title": "Ach, lieben Christen, seid getrost",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0115",
+    "BC": "A156",
+    "Title": "Mache dich, mein Geist, bereit",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0116",
+    "BC": "A164",
+    "Title": "Du Friedefürst, Herr Jesu Christ",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0117",
+    "BC": "A187",
+    "Title": "Sei Lob und Ehr dem höchsten Gut",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1728–31?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0118",
+    "BC": "B23",
+    "Title": "O Jesu Christ, mein's Lebens Licht",
+    "Forces": "ch orch",
+    "Key": "B♭major",
+    "Date": "1736–37, rev. 1746–47?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0119",
+    "BC": "B03",
+    "Title": "Preise, Jerusalem, den Herren",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0120",
+    "BC": "B06",
+    "Title": "Gott, man lobet dich in der Stille",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1728–29?",
+    "Genre": "Vocal",
+    "Notes": "re-used in BWV 120a,  120b"
+  },
+  {
+    "BWV": "0120a",
+    "BC": "B15",
+    "Title": "Herr Gott, Beherrscher aller Dinge",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1729?",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 120; partly lost"
+  },
+  {
+    "BWV": "0120b",
+    "BC": "B28",
+    "Title": "Gott, man lobet dich in der Stille",
+    "Forces": "",
+    "Key": "",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "lost"
+  },
+  {
+    "BWV": "0121",
+    "BC": "A013",
+    "Title": "Christum wir sollen loben schon",
+    "Forces": "4vv ch orch",
+    "Key": "E minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0122",
+    "BC": "A019",
+    "Title": "Das neugeborne Kindelein",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0123",
+    "BC": "A028",
+    "Title": "Liebster Immanuel, Herzog der Frommen",
+    "Forces": "3vv ch orch",
+    "Key": "B minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0124",
+    "BC": "A030",
+    "Title": "Meinen Jesum lass ich nicht",
+    "Forces": "4vv ch orch",
+    "Key": "E major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0125",
+    "BC": "A168",
+    "Title": "Mit Fried und Freud ich fahr dahin",
+    "Forces": "3vv ch orch",
+    "Key": "E minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0126",
+    "BC": "A046",
+    "Title": "Erhalt uns, Herr, bei deinem Wort",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0127",
+    "BC": "A049",
+    "Title": "Herr Jesu Christ, wahr' Mensch und Gott",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0128",
+    "BC": "A076",
+    "Title": "Auf Christi Himmelfahrt allein",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0129",
+    "BC": "A093",
+    "Title": "Gelobet sei der Herr, mein Gott",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0130",
+    "BC": "A179",
+    "Title": "Herr Gott, dich loben alle wir",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0131",
+    "BC": "B25",
+    "Title": "Aus der Tiefe rufe ich, Herr, zu dir",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1707–08",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0131a",
+    "BC": "J62",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; arr. from the finale of BWV 131"
+  },
+  {
+    "BWV": "0132",
+    "BC": "A006",
+    "Title": "Bereitet die Wege, bereitet die Bahn",
+    "Forces": "4vv ch orch",
+    "Key": "A major",
+    "Date": "1715",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0133",
+    "BC": "A016",
+    "Title": "Ich freue mich in dir",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0134",
+    "BC": "A059",
+    "Title": "Ein Herz, das seinen Jesum lebend weiß",
+    "Forces": "2vv ch orch",
+    "Key": "B♭major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 134a"
+  },
+  {
+    "BWV": "0134a",
+    "BC": "G05",
+    "Title": "Die Zeit, die Tag und Jahre macht",
+    "Forces": "2vv ch orch",
+    "Key": "B♭major",
+    "Date": "1718",
+    "Genre": "Vocal",
+    "Notes": "rev. as BWV 134"
+  },
+  {
+    "BWV": "0135",
+    "BC": "A100",
+    "Title": "Ach Herr, mich armen Sünder",
+    "Forces": "3vv ch orch",
+    "Key": "E minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0136",
+    "BC": "A111",
+    "Title": "Erforsche mich, Gott, und erfahre mein Herz",
+    "Forces": "3vv ch orch",
+    "Key": "A major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 234"
+  },
+  {
+    "BWV": "0137",
+    "BC": "A124",
+    "Title": "Lobe den Herren, den mächtigen König der Ehren",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "movt.II adapted in BWV 650"
+  },
+  {
+    "BWV": "0138",
+    "BC": "A132",
+    "Title": "Warum betrübst du dich, mein Herz",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 236"
+  },
+  {
+    "BWV": "0139",
+    "BC": "A159",
+    "Title": "Wohl dem, der sich auf seinen Gott",
+    "Forces": "4vv ch orch",
+    "Key": "E major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0140",
+    "BC": "A166",
+    "Title": "Wachet auf, ruft uns die Stimme",
+    "Forces": "3vv ch orch",
+    "Key": "E♭major",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "movt.IV adapted in BWV 645"
+  },
+  {
+    "BWV": "0141",
+    "BC": "V03",
+    "Title": "Das ist je gewisslich wahr",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann"
+  },
+  {
+    "BWV": "0142",
+    "BC": "V04",
+    "Title": "Uns ist ein Kind geboren",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; probably compoed byJohann Kuhnau"
+  },
+  {
+    "BWV": "0143",
+    "BC": "T01",
+    "Title": "Lobe den Herrn, meine Seele",
+    "Forces": "3vv ch orch",
+    "Key": "B♭major",
+    "Date": "1708–14",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0144",
+    "BC": "A041",
+    "Title": "Nimm, was dein ist, und gehe hin",
+    "Forces": "3vv ch orch",
+    "Key": "B minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0145",
+    "BC": "A060",
+    "Title": "Ich lebe, mein Herze, zu deinem Ergötzen",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0146",
+    "BC": "A070",
+    "Title": "Wir müssen durch viel Trübsal in das Reich Gottes eingehen",
+    "Forces": "4vv ch orch",
+    "Key": "D minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly based on a lost violin concerto (see BWV 1052R)"
+  },
+  {
+    "BWV": "0147",
+    "BC": "A174",
+    "Title": "Herz und Mund und Tat und Leben",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 147a"
+  },
+  {
+    "BWV": "0147a",
+    "BC": "A007",
+    "Title": "Herz und Mund und Tat und Leben",
+    "Forces": "",
+    "Key": "",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": "rext is not lost, but only the first four sheets of the musical score survives; rev. as BWV 147"
+  },
+  {
+    "BWV": "0148",
+    "BC": "A140",
+    "Title": "Bringet dem Herrn Ehre seines Namens",
+    "Forces": "2vv ch orch",
+    "Key": "D major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0149",
+    "BC": "A181",
+    "Title": "Man singet mit Freuden vom Sieg",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0150",
+    "BC": "B24",
+    "Title": "Nach dir, Herr, verlanget mich",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1706",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0151",
+    "BC": "A017",
+    "Title": "Süsser Trost, mein Jesus kömmt",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1726, rev. 1727?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0152",
+    "BC": "A018",
+    "Title": "Tritt auf die Glaubensbahn",
+    "Forces": "2vv orch",
+    "Key": "",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0153",
+    "BC": "A025",
+    "Title": "Schau, lieber Gott, wie meine Feind",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0154",
+    "BC": "A029",
+    "Title": "Mein liebster Jesus ist verloren",
+    "Forces": "3vv ch orch",
+    "Key": "B minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0155",
+    "BC": "A032",
+    "Title": "Mein Gott, wie lang, ach lange",
+    "Forces": "4vv ch orch",
+    "Key": "D minor",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0156",
+    "BC": "A038",
+    "Title": "Ich steh mit einem Fuß im Grabe",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "sinfonia based on BWV 1056"
+  },
+  {
+    "BWV": "0157",
+    "BC": "A170",
+    "Title": "Ich lasse dich nicht, du segnest mich denn!",
+    "Forces": "2vv ch orch",
+    "Key": "B minor",
+    "Date": "1728",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 157a"
+  },
+  {
+    "BWV": "0157a",
+    "BC": "B20",
+    "Title": "Ich lasse dich nicht, du segnest mich denn!",
+    "Forces": "2vv ch orch",
+    "Key": "B minor",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "rev. as BWV 157"
+  },
+  {
+    "BWV": "0158",
+    "BC": "A061",
+    "Title": "Der Friede sei mit dir",
+    "Forces": "v ch ob vn bc",
+    "Key": "D major",
+    "Date": "1732–35",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 158a"
+  },
+  {
+    "BWV": "0158a",
+    "BC": "A061",
+    "Title": "Der Friede sei mit dir",
+    "Forces": "v ch ob vn bc",
+    "Key": "D major",
+    "Date": "1732–35",
+    "Genre": "Vocal",
+    "Notes": "incomplete; rev. as BWV 158"
+  },
+  {
+    "BWV": "0159",
+    "BC": "A050",
+    "Title": "Sehet, wir geh'n hinauf gen Jerusalem",
+    "Forces": "3vv ch orch",
+    "Key": "C minor",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0160",
+    "BC": "V05",
+    "Title": "Ich weiss, dass mein Erlöser lebt",
+    "Forces": "v bn vn bc",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:877)"
+  },
+  {
+    "BWV": "0161",
+    "BC": "A135",
+    "Title": "Komm, du süsse Todesstunde",
+    "Forces": "2vv ch orch",
+    "Key": "C major",
+    "Date": "1715",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0162",
+    "BC": "A090",
+    "Title": "Ach! ich sehe, itzt, da ich zur Hochzeit gehe",
+    "Forces": "4vv ch orch",
+    "Key": "A minor",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0163",
+    "BC": "A158",
+    "Title": "Nur jedem das Seine",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1715",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0164",
+    "BC": "A128",
+    "Title": "Ihr, die ihr euch von Christo nennet",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0165",
+    "BC": "A090",
+    "Title": "O heilges Geist- und Wasserbad",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1715",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0166",
+    "BC": "A071",
+    "Title": "Wo gehest du hin",
+    "Forces": "3vv ch orch",
+    "Key": "B♭major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0167",
+    "BC": "A176",
+    "Title": "Ihr Menschen, rühmet Gottes Liebe",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0168",
+    "BC": "A116",
+    "Title": "Tue Rechnung! Donnerwort",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0169",
+    "BC": "A143",
+    "Title": "Gott soll allein mein Herze haben",
+    "Forces": "v ch orch",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "partly based on a lost oboe concerto (see BWV 1053R)"
+  },
+  {
+    "BWV": "0170",
+    "BC": "A106",
+    "Title": "Vergnügte Ruh, beliebte Seelenlust",
+    "Forces": "v orch",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0171",
+    "BC": "A024",
+    "Title": "Gott, wie dein Name, so ist auch dein Ruhm",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1728?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0172/1",
+    "BC": "A081a",
+    "Title": "Erschallet, ihr Lieder",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": "1st version"
+  },
+  {
+    "BWV": "0172/2",
+    "BC": "A081b",
+    "Title": "Erschallet, ihr Lieder",
+    "Forces": "4vv ch orch",
+    "Key": "C major",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "2nd version"
+  },
+  {
+    "BWV": "0173",
+    "BC": "A085",
+    "Title": "Erhöhtes Fleisch und Blut",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 173a"
+  },
+  {
+    "BWV": "0173a",
+    "BC": "G09",
+    "Title": "Durchlauchtster Leopold",
+    "Forces": "2vv orch",
+    "Key": "D major",
+    "Date": "1717–22?",
+    "Genre": "Vocal",
+    "Notes": "rev. as BWV 173"
+  },
+  {
+    "BWV": "0174",
+    "BC": "A087",
+    "Title": "Ich liebe den Höchsten von ganzem Gemüte",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "Sinfonia (No. 1) based on the 1st movt. of the Brandenburg Concerto No.3 BWV 1048."
+  },
+  {
+    "BWV": "0175",
+    "BC": "A089",
+    "Title": "Er rufet seinen Schafen mit Namen",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0176",
+    "BC": "A092",
+    "Title": "Es ist ein trotzig und verzagt Ding",
+    "Forces": "3vv ch orch",
+    "Key": "C minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0177",
+    "BC": "A103",
+    "Title": "Ich ruf zu dir, Herr Jesu Christ",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1732",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0178",
+    "BC": "A112",
+    "Title": "Wo Gott der Herr nicht bei uns hält",
+    "Forces": "3vv ch orch",
+    "Key": "A minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0179",
+    "BC": "A121",
+    "Title": "Siehe zu, dass deine Gottesfurcht",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 234, BWV 236"
+  },
+  {
+    "BWV": "0180",
+    "BC": "A149",
+    "Title": "Schmücke dich, o liebe Seele",
+    "Forces": "4vv ch orch",
+    "Key": "F major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0181/1",
+    "BC": "A045",
+    "Title": "Leichtgesinnte Flattergeister",
+    "Forces": "4vv ch orch",
+    "Key": "E minor",
+    "Date": "1724, rev. 1743–46",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0182/1",
+    "BC": "A053",
+    "Title": "Himmelskönig, sei willkommen",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": "1st version"
+  },
+  {
+    "BWV": "0182/2",
+    "BC": "A172",
+    "Title": "Himmelskönig, sei willkommen",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1728",
+    "Genre": "Vocal",
+    "Notes": "2nd version"
+  },
+  {
+    "BWV": "0183",
+    "BC": "A079",
+    "Title": "Sie werden euch in den Bann tun",
+    "Forces": "4vv ch orch",
+    "Key": "A minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0184",
+    "BC": "A088",
+    "Title": "Erwünschtes Freudenlicht",
+    "Forces": "3vv ch orch",
+    "Key": "G major",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 184a"
+  },
+  {
+    "BWV": "0184a",
+    "BC": "G08",
+    "Title": "Cantata",
+    "Forces": "",
+    "Key": "G major",
+    "Date": "1720",
+    "Genre": "Vocal",
+    "Notes": "lost; possibly the same as BWV Anh.8; rev. as BWV 184"
+  },
+  {
+    "BWV": "0185",
+    "BC": "A101",
+    "Title": "Barmherziges Herze der ewigen Liebe",
+    "Forces": "4vv ch orch",
+    "Key": "F♯minor",
+    "Date": "1715",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0186",
+    "BC": "A108",
+    "Title": "ArgeÄrgre dich, o Seele, nicht",
+    "Forces": "4vv ch orch",
+    "Key": "G minor",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 186a"
+  },
+  {
+    "BWV": "0186a",
+    "BC": "A108",
+    "Title": "ArgeÄrgre dich, o Seele, nicht",
+    "Forces": "",
+    "Key": "",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": "text not lost, but music survives in a few individual parts; rev. as BWV 186"
+  },
+  {
+    "BWV": "0187",
+    "BC": "A110",
+    "Title": "Es wartet alles auf dich",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "parts re-used in BWV 235"
+  },
+  {
+    "BWV": "0188",
+    "BC": "A154",
+    "Title": "Ich habe meine Zuversicht",
+    "Forces": "4vv ch orch",
+    "Key": "D minor",
+    "Date": "1728",
+    "Genre": "Vocal",
+    "Notes": "sinfonia based on a lost violin concerto (see BWV 1052R)"
+  },
+  {
+    "BWV": "0189",
+    "BC": "V06",
+    "Title": "Meine Seele rühmt und preist",
+    "Forces": "v orch",
+    "Key": "B♭major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byMelchior Hoffmann"
+  },
+  {
+    "BWV": "0190",
+    "BC": "A021",
+    "Title": "Singet dem Herrn ein neues Lied",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "partly lost; rev. as BWV 190a"
+  },
+  {
+    "BWV": "0190a",
+    "BC": "B27",
+    "Title": "Singet dem Herrn ein neues Lied",
+    "Forces": "",
+    "Key": "D major",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "lost"
+  },
+  {
+    "BWV": "0191",
+    "BC": "E16",
+    "Title": "Gloria in excelsis Deo",
+    "Forces": "2vv ch orch",
+    "Key": "D major",
+    "Date": "1741–45",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 232/1"
+  },
+  {
+    "BWV": "0192",
+    "BC": "A188",
+    "Title": "Nun danket alle Gott",
+    "Forces": "2vv ch orch",
+    "Key": "G major",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "partly lost"
+  },
+  {
+    "BWV": "0193",
+    "BC": "B05",
+    "Title": "Ihr Tore zu Zion",
+    "Forces": "2vv ch orch",
+    "Key": "D major",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0193a",
+    "BC": "G15",
+    "Title": "Ihr Häuser des Himmels, ihr scheinenden Lichter",
+    "Forces": "",
+    "Key": "",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "lost"
+  },
+  {
+    "BWV": "0194",
+    "BC": "A091",
+    "Title": "Höchsterwünschtes Freudenfest",
+    "Forces": "3vv ch orch",
+    "Key": "B♭major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 194a"
+  },
+  {
+    "BWV": "0194a",
+    "BC": "G11",
+    "Title": "Cantata[for the consecration of the organ at Störmthal]",
+    "Forces": "",
+    "Key": "",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "lost; rev. as BWV 194"
+  },
+  {
+    "BWV": "0195",
+    "BC": "B14",
+    "Title": "Dem Gerechten muss das Licht",
+    "Forces": "",
+    "Key": "D major",
+    "Date": "1727–31, rev. 1742, 1748–49",
+    "Genre": "Vocal",
+    "Notes": "partly lost"
+  },
+  {
+    "BWV": "0196",
+    "BC": "B11",
+    "Title": "Der Herr denket an uns",
+    "Forces": "3vv ch orch",
+    "Key": "C major",
+    "Date": "1707–08",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0197",
+    "BC": "B16",
+    "Title": "Gott ist unsre Zuversicht",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1736–37",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 197a"
+  },
+  {
+    "BWV": "0197a",
+    "BC": "A011",
+    "Title": "Ehre sei Gott in der Höhe",
+    "Forces": "2vv ch orch",
+    "Key": "D major",
+    "Date": "1728",
+    "Genre": "Vocal",
+    "Notes": "re-used in BWV 197; partly lost"
+  },
+  {
+    "BWV": "0198",
+    "BC": "G34",
+    "Title": "Lass, Fürstin, lass noch einen Strahl(Trauer-Ode)",
+    "Forces": "4vv ch orch",
+    "Key": "B minor",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 244a, BWV 247"
+  },
+  {
+    "BWV": "0199",
+    "BC": "A120",
+    "Title": "Mein Herze schwimmt im Blut",
+    "Forces": "v orch",
+    "Key": "C minor",
+    "Date": "1714",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0200",
+    "BC": "A192",
+    "Title": "Bekennen will ich seinen Namen",
+    "Forces": "v 2vn bc",
+    "Key": "E major",
+    "Date": "1742–43",
+    "Genre": "Vocal",
+    "Notes": "incomplete (aria only)"
+  },
+  {
+    "BWV": "0201",
+    "BC": "G46",
+    "Title": "Geschwinde, ihr wirbelnden Winde(Der Streit zwischen Phoebus und Pan)",
+    "Forces": "6vv ch orch",
+    "Key": "D major",
+    "Date": "1729?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0202",
+    "BC": "G41",
+    "Title": "Weichet nur, betrübte Schatten",
+    "Forces": "v ob str bc",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0203",
+    "BC": "G51",
+    "Title": "Amore traditore",
+    "Forces": "v hpd",
+    "Key": "A minor",
+    "Date": "1723?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0204",
+    "BC": "G45",
+    "Title": "Ich bin in mir vergnügt",
+    "Forces": "v orch",
+    "Key": "B♭major",
+    "Date": "1726–27",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0205",
+    "BC": "G36",
+    "Title": "Zerreißet, zersprenget, zertrümmert die Gruft(Der zufriedengestellte Aeolus)",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "dramma per musica, for the birthday of Professor Augustus Friedrich Müller; parts re-used in BWV 205a"
+  },
+  {
+    "BWV": "0205a",
+    "BC": "G20",
+    "Title": "Blast Lärmen, ihr Feinde! verstärket die Macht",
+    "Forces": "",
+    "Key": "D major",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0206/1",
+    "BC": "G23",
+    "Title": "Schleicht, spielende Wellen",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "1st version"
+  },
+  {
+    "BWV": "0206/2",
+    "BC": "G26",
+    "Title": "Schleicht, spielende Wellen",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1740",
+    "Genre": "Vocal",
+    "Notes": "2nd version"
+  },
+  {
+    "BWV": "0207",
+    "BC": "G37",
+    "Title": "Vereinigte Zwietracht der wechselnden Saiten",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0207a",
+    "BC": "G22",
+    "Title": "Auf, schmetternde Töne der muntern Trompeten",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "1735",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0208/1",
+    "BC": "G01",
+    "Title": "Was mir behagt, ist nur die muntre Jagd(Jagdkantate)",
+    "Forces": "4vv orch",
+    "Key": "F major",
+    "Date": "1713",
+    "Genre": "Vocal",
+    "Notes": "1st version of BWV 208/2; partly re-used in BWV 208a, BWV Anh.193"
+  },
+  {
+    "BWV": "0208/2",
+    "BC": "G03",
+    "Title": "Was mir behagt, ist nur die muntre Jagd(Jagdkantate)",
+    "Forces": "4vv orch",
+    "Key": "F major",
+    "Date": "1716?",
+    "Genre": "Vocal",
+    "Notes": "2nd version of BWV 208/1"
+  },
+  {
+    "BWV": "0208a",
+    "BC": "G26",
+    "Title": "Was mir behagt, ist nur die muntre Jagd(Frolockender Goetterstreit)",
+    "Forces": "",
+    "Key": "F major",
+    "Date": "1740?",
+    "Genre": "Vocal",
+    "Notes": "cantata for the nameday of King August III; based on BWV 208; lost"
+  },
+  {
+    "BWV": "0209",
+    "BC": "G50",
+    "Title": "Non sa che sia dolore",
+    "Forces": "v fl str bc",
+    "Key": "B minor",
+    "Date": "1729?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0210",
+    "BC": "G44",
+    "Title": "O holder Tag, erwünschte Zeit",
+    "Forces": "v orch",
+    "Key": "A major",
+    "Date": "1738–41?",
+    "Genre": "Vocal",
+    "Notes": "re-used in BWV 210?"
+  },
+  {
+    "BWV": "0210a",
+    "BC": "G29",
+    "Title": "O angenehme Melodei",
+    "Forces": "",
+    "Key": "A major",
+    "Date": "1740",
+    "Genre": "Vocal",
+    "Notes": "incomplete; based on BWV 210?"
+  },
+  {
+    "BWV": "0211",
+    "BC": "G48",
+    "Title": "Schweigt stille, plaudert nicht(\"Kaffee-Kantate\" / \"Coffee Cantata\")",
+    "Forces": "3vv orch",
+    "Key": "G major",
+    "Date": "1732–34",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0212",
+    "BC": "G32",
+    "Title": "Mer hahn en neue Oberkeet(\"Bauernkantate\" / \"Peasant Cantata\")",
+    "Forces": "2vv orch",
+    "Key": "A major",
+    "Date": "1742",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0213",
+    "BC": "G18",
+    "Title": "Laßt uns sorgen, laßt uns wachen(\"Hercules auf dem Scheidewege\")",
+    "Forces": "5vv ch orch",
+    "Key": "F major",
+    "Date": "1733",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 248/1–5"
+  },
+  {
+    "BWV": "0214",
+    "BC": "G19",
+    "Title": "Tönet, ihr Pauken! Erschallet, Trompeten!",
+    "Forces": "4vv orch",
+    "Key": "D major",
+    "Date": "1733",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0215",
+    "BC": "G21",
+    "Title": "Preise dein Glücke, gesegnetes Sachsen",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "partly re-used in BWV 248/1–5"
+  },
+  {
+    "BWV": "0216",
+    "BC": "G43",
+    "Title": "Vergnügte Pleissenstadt(Apollo et Mercurius)",
+    "Forces": "2vv (orch?)",
+    "Key": "C major",
+    "Date": "1728",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0216a",
+    "BC": "G47",
+    "Title": "Erwählte Pleissenstadt(Apollo et Mercurius)",
+    "Forces": "",
+    "Key": "",
+    "Date": "1728",
+    "Genre": "Vocal",
+    "Notes": "lost"
+  },
+  {
+    "BWV": "0217",
+    "BC": "V07",
+    "Title": "Gedenke, Herr, wie es uns gehet",
+    "Forces": "4vv ch orch",
+    "Key": "D minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; probably composed by Johann Christoph Altnikol"
+  },
+  {
+    "BWV": "0218",
+    "BC": "V08",
+    "Title": "Gott der Hoffnung erfülle euch",
+    "Forces": "4vv ch orch",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:634)"
+  },
+  {
+    "BWV": "0219",
+    "BC": "V09",
+    "Title": "Siehe, es hat überwunden",
+    "Forces": "3vv ch orch",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:1328)"
+  },
+  {
+    "BWV": "0220",
+    "BC": "V10",
+    "Title": "Lobt ihn mit Herz und Munde",
+    "Forces": "3vv ch orch",
+    "Key": "B minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composer unidentified"
+  },
+  {
+    "BWV": "0221",
+    "BC": "V11",
+    "Title": "Wer sucht die Pracht, wer wünscht den Glanz",
+    "Forces": "2vv orch",
+    "Key": "B minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composer unidentified"
+  },
+  {
+    "BWV": "0222",
+    "BC": "V12",
+    "Title": "Mein Odem ist schwach",
+    "Forces": "3vv ch org str",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Ernst Bach"
+  },
+  {
+    "BWV": "0223",
+    "BC": "A186",
+    "Title": "Meine Seele soll Gott loben",
+    "Forces": "",
+    "Key": "B♭major",
+    "Date": "1707–08?",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0224",
+    "BC": "T02",
+    "Title": "Reißt euch los, bekränkte Sinnen",
+    "Forces": "",
+    "Key": "D minor",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "incomplete; spurious; probably composed byCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "0225",
+    "BC": "C1",
+    "Title": "Singet dem Herrn ein neues Lied",
+    "Forces": "2ch",
+    "Key": "B♭major",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0226",
+    "BC": "C2",
+    "Title": "Der Geist hilft unser Schwachheit auf",
+    "Forces": "2ch orch",
+    "Key": "B♭major",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0227",
+    "BC": "C5",
+    "Title": "Jesu, meine Freude",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "1723?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0228",
+    "BC": "C4",
+    "Title": "Fürchte dich nicht, ich bin bei dir",
+    "Forces": "2ch",
+    "Key": "A major",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "A major"
+  },
+  {
+    "BWV": "0229",
+    "BC": "C3",
+    "Title": "Komm, Jesu, komm",
+    "Forces": "2ch",
+    "Key": "G minor",
+    "Date": "1723–24?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0230",
+    "BC": "C6",
+    "Title": "Lobet den Herrn, alle Heiden(Psalm 117)",
+    "Forces": "ch bc",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0231",
+    "BC": "C7",
+    "Title": "Sei Lob und Preis mit Ehren",
+    "Forces": "2ch",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "based partly on BWV 28 and music byGeorg Philipp Telemann; spurious; probably composed by Johann Gottlob Harrer"
+  },
+  {
+    "BWV": "0232",
+    "BC": "E01",
+    "Title": "Mass",
+    "Forces": "5vv ch orch",
+    "Key": "B minor",
+    "Date": "1747–49",
+    "Genre": "Vocal",
+    "Notes": "assembled from previous compositions"
+  },
+  {
+    "BWV": "0233",
+    "BC": "E06",
+    "Title": "Mass",
+    "Forces": "3vv ch orch",
+    "Key": "F major",
+    "Date": "1738–39?",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 233a, BWV 11, BWV 40, BWV 102, BWV Anh.18"
+  },
+  {
+    "BWV": "0233a",
+    "BC": "E07",
+    "Title": "Kyrie(\"Christe du Lamm Gottes\")",
+    "Forces": "ch bc",
+    "Key": "F major",
+    "Date": "1708–17?",
+    "Genre": "Vocal",
+    "Notes": "rev. in BWV 233"
+  },
+  {
+    "BWV": "0234",
+    "BC": "E03",
+    "Title": "Mass",
+    "Forces": "3vv ch orch",
+    "Key": "A major",
+    "Date": "1738–39?",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 67, BWV 79, BWV 136, BWV 179"
+  },
+  {
+    "BWV": "0235",
+    "BC": "E05",
+    "Title": "Mass",
+    "Forces": "3vv ch orch",
+    "Key": "G minor",
+    "Date": "1738–39?",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 72, BWV 102, BWV 187"
+  },
+  {
+    "BWV": "0236",
+    "BC": "E04",
+    "Title": "Mass",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "1738–39?",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 17, BWV 79, BWV 138, BWV 179"
+  },
+  {
+    "BWV": "0237",
+    "BC": "E10",
+    "Title": "Sanctus",
+    "Forces": "ch orch",
+    "Key": "C major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0238",
+    "BC": "E11",
+    "Title": "Sanctus",
+    "Forces": "ch orch",
+    "Key": "D major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0239",
+    "BC": "—",
+    "Title": "Sanctus",
+    "Forces": "ch str bc",
+    "Key": "D minor",
+    "Date": "1738–41?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0240",
+    "BC": "—",
+    "Title": "Sanctus",
+    "Forces": "ch orch",
+    "Key": "G major",
+    "Date": "1742?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0241",
+    "BC": "E17",
+    "Title": "Sanctus",
+    "Forces": "2ch orch",
+    "Key": "D major",
+    "Date": "1747–48",
+    "Genre": "Vocal",
+    "Notes": "arr. of theSanctusfrom theMissa superbaby Johann Kasper Kerll"
+  },
+  {
+    "BWV": "0242",
+    "BC": "E08",
+    "Title": "Christe eleison",
+    "Forces": "2vv ch orch",
+    "Key": "G minor",
+    "Date": "1727–32",
+    "Genre": "Vocal",
+    "Notes": "adapted from a Mass in C minor byFrancesco Durante(see BWV Anh.26)"
+  },
+  {
+    "BWV": "0243",
+    "BC": "E14",
+    "Title": "Magnificat",
+    "Forces": "5vv ch orch",
+    "Key": "D major",
+    "Date": "1733",
+    "Genre": "Vocal",
+    "Notes": "2nd version of BWV 243a"
+  },
+  {
+    "BWV": "0243a",
+    "BC": "E14",
+    "Title": "Magnificat",
+    "Forces": "5vv ch orch",
+    "Key": "E♭major",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "1st version of BWV 243"
+  },
+  {
+    "BWV": "0244",
+    "BC": "D03b",
+    "Title": "Matthäuspassion(St. Matthew Passion)",
+    "Forces": "vv 2ch 2orch",
+    "Key": "",
+    "Date": "1736–42",
+    "Genre": "Vocal",
+    "Notes": "2nd version of BWV 244b"
+  },
+  {
+    "BWV": "0244a",
+    "BC": "B22",
+    "Title": "Klagt, Kinder, klagt es aller Welt",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1143. Partly based on BWV 198, BWV 247, BWV 244b; lost"
+  },
+  {
+    "BWV": "0244b",
+    "BC": "D03a",
+    "Title": "Matthäuspassion(St. Matthew Passion)",
+    "Forces": "v 2ch 2orch",
+    "Key": "",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "1st version of BWV 244; text partly re-used in BWV 244a"
+  },
+  {
+    "BWV": "0245",
+    "BC": "D02",
+    "Title": "Johannespassion(St. John Passion)",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1724, rev. 1725–49",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0246",
+    "BC": "D06",
+    "Title": "Lukaspassion(St. Luke Passion)",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; probably composed by Johann Melchior Molter"
+  },
+  {
+    "BWV": "0247",
+    "BC": "D04",
+    "Title": "Markuspassion(St. Mark Passion)",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 198, BWV 54; lost, but various modern reconstructions exist; partly rev. in BWV 248?"
+  },
+  {
+    "BWV": "0248",
+    "BC": "D07",
+    "Title": "Weihnachts-Oratorium(Christmas Oratorio):",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0248/1",
+    "BC": "D07/1",
+    "Title": "Jauchzet, frohlocket, auf, preiset die Tage",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 213, BWV 215"
+  },
+  {
+    "BWV": "0248/2",
+    "BC": "D07/2",
+    "Title": "Und es waren Hirten in derselben Gegend",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 213, BWV 215"
+  },
+  {
+    "BWV": "0248/3",
+    "BC": "D07/3",
+    "Title": "Herrscher des Himmels, erhöre das Lallen",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 213, BWV 215"
+  },
+  {
+    "BWV": "0248/4",
+    "BC": "D07/4",
+    "Title": "Fallt mit Danken, fallt mit Loben",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 213, BWV 215"
+  },
+  {
+    "BWV": "0248/5",
+    "BC": "D07/5",
+    "Title": "Ehre sei dir, Gott, gesungen",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "partly based on BWV 213, BWV 215"
+  },
+  {
+    "BWV": "0248/6",
+    "BC": "D07/6",
+    "Title": "Herr, wenn die stolzen Feinde schnauben",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "based on BWV 248a"
+  },
+  {
+    "BWV": "0248a",
+    "BC": "A190",
+    "Title": "Cantata",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1730–34?",
+    "Genre": "Vocal",
+    "Notes": "incomplete; rev. as BWV 248/6"
+  },
+  {
+    "BWV": "0249/1",
+    "BC": "D08a",
+    "Title": "Kommt, eilet und laufet",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "cantata for Easter Sunday; based on BWV.249a; 1st version of BWV 249/2"
+  },
+  {
+    "BWV": "0249/2",
+    "BC": "D08b",
+    "Title": "Oster-Oratorium(Easter Oratorio)",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1738",
+    "Genre": "Vocal",
+    "Notes": "2nd version of BWV 249/1"
+  },
+  {
+    "BWV": "0249a",
+    "BC": "G02",
+    "Title": "Entfliehet, verschwindet, entweichet, ihr Sorgen(\"Schäferkantate\" or \"Shepherd Cantata\")",
+    "Forces": "4vv orch",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "lost; rev. as BWV.249/1"
+  },
+  {
+    "BWV": "0249b",
+    "BC": "G28",
+    "Title": "Verjaget, zerstreuet, zerrütet, ihr Sterne(\"Die Feier des Genius\")",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": "lost"
+  },
+  {
+    "BWV": "0250",
+    "BC": "B017/1",
+    "Title": "Was Gott tut, das ist wohlgetan",
+    "Forces": "ch orch",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0251",
+    "BC": "B017/2",
+    "Title": "Sei Lob und Ehr dem höchsten Gut",
+    "Forces": "ch orch",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0252",
+    "BC": "B017/3",
+    "Title": "Nun danket alle Gott",
+    "Forces": "ch orch",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0253",
+    "BC": "F035.1",
+    "Title": "Ach bleib bei uns, Herr Jesu Christ",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0254",
+    "BC": "F001.1",
+    "Title": "Ach Gott, erhör mein Seufzen",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0255",
+    "BC": "F002.1",
+    "Title": "Ach Gott und Herr",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0256",
+    "BC": "F212.3",
+    "Title": "Ach, lieben Christen, seid getrost",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0257",
+    "BC": "F212.1",
+    "Title": "Wär Gott nicht mit uns diese Zeit",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0258",
+    "BC": "F212.2",
+    "Title": "Wo Gott der Herr nicht bei uns hält",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0259",
+    "BC": "F005.1",
+    "Title": "Ach, was soll ich Sünder machen",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0260",
+    "BC": "F010.1",
+    "Title": "Allein Gott in der Höh sei Ehr",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0261",
+    "BC": "F011.1",
+    "Title": "Allein zu dir, Herr Jesu Christ",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0262",
+    "BC": "F008.1",
+    "Title": "Alle Menschen müssen sterben",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0263",
+    "BC": "F012.1",
+    "Title": "Alles ist an Gottes Segen",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0264",
+    "BC": "F013.1",
+    "Title": "Als der gütige Gott vollenden wollt sein Wort",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0265",
+    "BC": "F014.1",
+    "Title": "Als Jesus Christus in der Nacht",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0266",
+    "BC": "F015.1",
+    "Title": "Als vierzig Tag nach Ostern war",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0267",
+    "BC": "F017.1a-c",
+    "Title": "An Wasserflüssen Babylon",
+    "Forces": "ch",
+    "Key": "G/A♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0268",
+    "BC": "F019.1",
+    "Title": "Auf, auf, mein Herz, und du, mein ganzer Sinn",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0269",
+    "BC": "F021.1",
+    "Title": "Aus meines Herzens Grunde",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0270",
+    "BC": "F092.1",
+    "Title": "Befiehl du deine Wege(I)",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0271",
+    "BC": "F092.2",
+    "Title": "Befiehl du deine Wege(II)",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0272",
+    "BC": "F136.2",
+    "Title": "Befiehl du deine Wege(III)",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0273",
+    "BC": "F024.1",
+    "Title": "Christ, der du bist der helle Tag",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0274",
+    "BC": "F027.1",
+    "Title": "Christe, der du bist Tag und Licht",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0275",
+    "BC": "F028.1",
+    "Title": "Christe du Beistand deiner Kreuzgemeine",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0276",
+    "BC": "F025.1",
+    "Title": "Christ ist erstanden'",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0277",
+    "BC": "F026.2",
+    "Title": "Christ lag in Todes Banden(I)",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0278",
+    "BC": "F026.1",
+    "Title": "Christ lag in Todes Banden(II)",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0279",
+    "BC": "A61/4",
+    "Title": "Christ lag in Todes Banden(III)",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0280",
+    "BC": "F065.1",
+    "Title": "Christ, unser Herr, zum Jordankam",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0281",
+    "BC": "F030.1",
+    "Title": "Christus, der ist mein Leben(I)",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0282",
+    "BC": "F030.2",
+    "Title": "Christus, der ist mein Leben(II)",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0283",
+    "BC": "F031.1",
+    "Title": "Christus, der uns selig macht",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0284",
+    "BC": "F032.1",
+    "Title": "Christus ist erstanden, hat überwunden",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0285",
+    "BC": "F034.1",
+    "Title": "Da der Herr Christ zu Tischesass",
+    "Forces": "ch",
+    "Key": "C minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0286",
+    "BC": "F183.1",
+    "Title": "Danket dem Herren, denn er istsehr freundlich",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0287",
+    "BC": "F119.1",
+    "Title": "Dank sei Gott in der Höhe",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0288",
+    "BC": "F036.1",
+    "Title": "Das alte Jahr vergangen ist(I)",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0289",
+    "BC": "F036.2",
+    "Title": "Das alte Jahr vergangen ist(II)",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0290",
+    "BC": "F038.1",
+    "Title": "Das walt mein Gott Vater und Gott Sohn",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0291",
+    "BC": "F039.1",
+    "Title": "Das walt mein Gott Vater und Gott Sohn und heilger Geist",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0292",
+    "BC": "F040.1",
+    "Title": "Den Vater dort oben",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0293",
+    "BC": "F042.1",
+    "Title": "Der du bist drei in Einigkeit",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0294",
+    "BC": "F043.1",
+    "Title": "Der Tag, der ist so freudenreich",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0295",
+    "BC": "F178.1",
+    "Title": "Des heilgen Geistes reiche Gnad",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0296",
+    "BC": "F044.1",
+    "Title": "Die Nacht ist kommen",
+    "Forces": "ch",
+    "Key": "G Mixolydian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0297",
+    "BC": "F161.1",
+    "Title": "Die Sonn hat sich mit ihrem Glanz",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0298",
+    "BC": "F046.1",
+    "Title": "Dies sind die heilgen zehn Gebot",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0299",
+    "BC": "F047.1",
+    "Title": "Dir, dir, Jehova, will ich singen",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0300",
+    "BC": "F051.1",
+    "Title": "Du grosser Schmerzensmann",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0301",
+    "BC": "F050.1",
+    "Title": "Du, o schönes Weltgebäude",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0302",
+    "BC": "F053.1a-b",
+    "Title": "Ein feste Burg ist unser Gott(I)",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0303",
+    "BC": "F053.2",
+    "Title": "Ein feste Burg ist unser Gott(II)",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0304",
+    "BC": "F054.1",
+    "Title": "Eins ist Not! ach Herr, dies Eine",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0305",
+    "BC": "F055.1",
+    "Title": "Erbarm dich mein, o Herre Gott",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0306",
+    "BC": "F058.1",
+    "Title": "Erstanden ist der heilge Christ",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0307",
+    "BC": "F150.1",
+    "Title": "Es ist gewisslich an der Zeit",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0308",
+    "BC": "F062.1",
+    "Title": "Es spricht der unweisen Mundwohl",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0309",
+    "BC": "F063.1",
+    "Title": "Es stehn vor Gottes Throne",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0310",
+    "BC": "F064.1",
+    "Title": "Es wird schier der letzte Tagherkommen",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0311",
+    "BC": "F066.2",
+    "Title": "Es woll uns Gott genädig sein(I)",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0312",
+    "BC": "F066.1",
+    "Title": "Es woll uns Gott genädig sein(II)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0313",
+    "BC": "F068.1",
+    "Title": "Für Freuden lasst uns springen",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0314",
+    "BC": "F069.1",
+    "Title": "Gelobet seist du, Jesu Christ",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0315",
+    "BC": "F070.1",
+    "Title": "Gib dich zufrieden und sei stille(I)",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0316",
+    "BC": "F071.1",
+    "Title": "Gott, der du selber bist das Licht",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0317",
+    "BC": "F072.1",
+    "Title": "Gott, der Vater wohn uns bei",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0318",
+    "BC": "F143.1a-b",
+    "Title": "Gottes Sohn ist kommen",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0319",
+    "BC": "F074.1",
+    "Title": "Gott hat das Evangeliums",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0320",
+    "BC": "F075.1",
+    "Title": "Gott lebet noch",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0321",
+    "BC": "F077.1",
+    "Title": "Gottlob, es geht nunmehr zu Ende",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0322",
+    "BC": "F076.1",
+    "Title": "Gott sei gelobet und gebenedeiet",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0323",
+    "BC": "F140.2",
+    "Title": "Gott sei uns gnädig und barmherzig",
+    "Forces": "ch",
+    "Key": "F♯minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0324",
+    "BC": "F140.1",
+    "Title": "Meine Seele erhebt den Herrn",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0325",
+    "BC": "F079.1",
+    "Title": "Heilig, heilig, heilig",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0326",
+    "BC": "F105.1",
+    "Title": "Herr Gott, dich loben alle wir",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0327",
+    "BC": "F105.2",
+    "Title": "Für deinen Thron tret ich hiermit",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0328",
+    "BC": "F083.1",
+    "Title": "Herr Gott, dich loben wir",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0329",
+    "BC": "F134.1",
+    "Title": "Herr, ich denk an jene Zeit",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0330",
+    "BC": "F084.2",
+    "Title": "Herr, ich habe missgehandelt(I)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0331",
+    "BC": "F084.1a-b",
+    "Title": "Herr, ich habe missgehandelt(II)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0332",
+    "BC": "F085.1",
+    "Title": "Herr Jesu Christ, dich zu unswend",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0333",
+    "BC": "F086.1",
+    "Title": "Herr Jesu Christ, du hast bereit",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0334",
+    "BC": "F202.1",
+    "Title": "Herr Jesu Christ, du höchstes Gut",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0335",
+    "BC": "F170.1",
+    "Title": "Herr Jesu Christ, meins Lebens Licht",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0336",
+    "BC": "F088.1",
+    "Title": "Herr Jesu Christ, wahr Menschund Gott",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0337",
+    "BC": "F089.1",
+    "Title": "Herr, nun lass in Friede",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0338",
+    "BC": "F090.1",
+    "Title": "Herr, straf mich nicht in deinem Zorn",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0339",
+    "BC": "F023.1a-b",
+    "Title": "Herr, wie du willst, so schicksmit mir",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0340",
+    "BC": "F091.1",
+    "Title": "Herzlich lieb hab ich dich, o Herr",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0341",
+    "BC": "F094.1a",
+    "Title": "Heut ist, o Mensch, ein grosser Trauertag",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0342",
+    "BC": "F095.1",
+    "Title": "Heut triumphieret Gottes Sohn",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0343",
+    "BC": "F096.1",
+    "Title": "Hilf, Gott, dass mir gelinge",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0344",
+    "BC": "F097.1",
+    "Title": "Hilf, Herr Jesu, lass gelingen",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0345",
+    "BC": "F099.1",
+    "Title": "Ich bin ja, Herr, in deiner Macht",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0346",
+    "BC": "F100.1",
+    "Title": "Ich dank dir, Gott, für all Wohltat",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0347",
+    "BC": "F101.2",
+    "Title": "Ich dank dir, lieber Herre(I)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0348",
+    "BC": "F101.1",
+    "Title": "Ich dank dir, lieber Herre(II)",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0349",
+    "BC": "F004.1",
+    "Title": "Ich dank dir schon durch deinen Sohn",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0350",
+    "BC": "F139.1",
+    "Title": "Ich dank dir, o Gott, in deinem Throne",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0351",
+    "BC": "F102.1",
+    "Title": "Ich hab mein Sach Gottheimgestellt",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0352",
+    "BC": "F187.3",
+    "Title": "Jesu, der du meine Seele(I)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0353",
+    "BC": "F187.1",
+    "Title": "Jesu, der du meine Seele(II)",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0354",
+    "BC": "F187.2",
+    "Title": "Jesu, der du meine Seele(III)",
+    "Forces": "ch",
+    "Key": "B♭Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0355",
+    "BC": "F112.1",
+    "Title": "Jesu, der du selbsten wohl",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0356",
+    "BC": "F113.1",
+    "Title": "Jesu, du mein liebstes Leben",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0357",
+    "BC": "F114.1",
+    "Title": "Jesu, Jesu, du bist mein",
+    "Forces": "ch",
+    "Key": "C Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0358",
+    "BC": "F116.1",
+    "Title": "Jesu, meine Freude",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0359",
+    "BC": "F206.1b",
+    "Title": "Jesu, meiner Seelen Wonne(I)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0360",
+    "BC": "F206.2",
+    "Title": "Jesu, meiner Seelen Wonne(II)",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0361",
+    "BC": "F117.1",
+    "Title": "Jesu, meines Herzens Freud",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0362",
+    "BC": "F118.1",
+    "Title": "Jesu, nun sei gepreiset",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0363",
+    "BC": "F121.1",
+    "Title": "Jesus Christus, unser Heiland(I)",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0364",
+    "BC": "F120.1",
+    "Title": "Jesus Christus, unser Heiland(II)",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0365",
+    "BC": "F123.1",
+    "Title": "Jesus, meine Zuversicht",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0366",
+    "BC": "F104.1",
+    "Title": "Ihr Gestrin, ihr hohlen Lüfte",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0367",
+    "BC": "F107.1",
+    "Title": "In allen meinen Taten",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0368",
+    "BC": "F110.1",
+    "Title": "In dulci jubilo",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0369",
+    "BC": "F124.1",
+    "Title": "Keinen hat Gott verlassen",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0370",
+    "BC": "F125.1",
+    "Title": "Komm, Gott Schöpfer, heiliger Geist",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0371",
+    "BC": "F129.1",
+    "Title": "Kyrie, Gott Vater in Ewigkeit",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0372",
+    "BC": "F082.1",
+    "Title": "Lass, o Herr, dein Ohr sichneigen",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0373",
+    "BC": "F133.1",
+    "Title": "Liebster Jesu, wir sind hier",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0374",
+    "BC": "F135.1",
+    "Title": "Lobet den Herrn, denn er ist sehrfreundlich",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0375",
+    "BC": "F127.1",
+    "Title": "Lobt Gott, ihr Christen, allzugleich(I)",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0376",
+    "BC": "F128.1",
+    "Title": "Lobt Gott, ihr Christen, allzugleich(II)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0377",
+    "BC": "F137.1",
+    "Title": "Machs mit mir, Gott, nach deiner Güt",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0378",
+    "BC": "F138.1",
+    "Title": "Mein augen schliess ich jetzt",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0379",
+    "BC": "F122.1",
+    "Title": "Meinem Jesum lass ich nicht, Jesus",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0380",
+    "BC": "F141.1a-b",
+    "Title": "Meinen Jesum lass ich nicht",
+    "Forces": "ch",
+    "Key": "E♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0381",
+    "BC": "F142.1",
+    "Title": "Meines Lebens letzte Zeit",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0382",
+    "BC": "F144.1",
+    "Title": "Mit Fried und Freud ich fahr dahin",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0383",
+    "BC": "F145.1",
+    "Title": "Mitten wir im Leben sind",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0384",
+    "BC": "F146.1",
+    "Title": "Nicht so traurig, nicht so sehr",
+    "Forces": "ch",
+    "Key": "C minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0385",
+    "BC": "F147.1",
+    "Title": "Nun bitten wir den heiligen Geist",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0386",
+    "BC": "F148.1",
+    "Title": "Nun danket alle Gott",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0387",
+    "BC": "F106.1",
+    "Title": "Nun freut euch, Gottes Kinder all",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0388",
+    "BC": "F149.1",
+    "Title": "Nun freut euch, lieben Christeng mein",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0389",
+    "BC": "F153.1",
+    "Title": "Nun lob, mein Seel, den Herren(I)",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0390",
+    "BC": "F153.2",
+    "Title": "Nun lob, mein Seel, den Herren(II)",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0391",
+    "BC": "F154.1",
+    "Title": "Nun preiset alle Gottes Barmherzigkeit",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0392",
+    "BC": "F166.9c",
+    "Title": "Nun ruhen alle Wälder",
+    "Forces": "ch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0393",
+    "BC": "F166.1a-b",
+    "Title": "O Welt, sieh hier dein Leben(I)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0394",
+    "BC": "F166.2",
+    "Title": "O Welt, sieh hier dein Leben(II)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0395",
+    "BC": "F166.5c",
+    "Title": "O Welt, sieh hier dein Leben(III)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0396",
+    "BC": "F155.1",
+    "Title": "Nun sich der Tag geendet hat",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0397",
+    "BC": "F156.1",
+    "Title": "O Ewigkeit, du Donnerwort",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0398",
+    "BC": "F045.2b",
+    "Title": "O Gott, du frommer Gott(II)",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0399",
+    "BC": "F157.1",
+    "Title": "O Gott, du frommer Gott(I)",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0400",
+    "BC": "F160.1",
+    "Title": "O Herzensangst, o Bangigkeit, und Zagen!",
+    "Forces": "ch",
+    "Key": "E♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0401",
+    "BC": "F162.1",
+    "Title": "O Lamm Gottes, unschuldig",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0402",
+    "BC": "F061.1",
+    "Title": "O Mensch, bewein dein Sünde gross",
+    "Forces": "ch",
+    "Key": "E♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0403",
+    "BC": "F163.1",
+    "Title": "O Mensch, schau Jesum Christuman",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0404",
+    "BC": "F165.1b",
+    "Title": "O Traurigkeit, o Herzeleid",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0405",
+    "BC": "F167.1",
+    "Title": "O wie selig seid ihr doch, ihr Frommen(I)",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0406",
+    "BC": "F007.1",
+    "Title": "O wie selig seid ihr doch, ihr Frommen(II)",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0407",
+    "BC": "F168.1",
+    "Title": "O wir armen Sünder",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0408",
+    "BC": "F094.1b",
+    "Title": "Schaut, ihr Sünder!",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0409",
+    "BC": "F173.1",
+    "Title": "Seelen-Bräutigam",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0410",
+    "BC": "F174.1",
+    "Title": "Sei gegrüsset, Jesu gütig",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0411",
+    "BC": "F175.1",
+    "Title": "Singet dem Herrn ein neues Lied",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0412",
+    "BC": "F177.1",
+    "Title": "So giebst du nun, mein Jesu, gute Nacht",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0413",
+    "BC": "F130.1",
+    "Title": "Sollt ich meinem Gott nichtsingen",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0414",
+    "BC": "F035.2",
+    "Title": "Uns ist ein Kindlein heut geborn",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0415",
+    "BC": "F0180.1",
+    "Title": "Valet will ich dir geben",
+    "Forces": "ch",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0416",
+    "BC": "F181.4a",
+    "Title": "Vater unser im Himmelreich",
+    "Forces": "ch",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0417",
+    "BC": "F185.1",
+    "Title": "Von Gott will ich nicht lassen(I)",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0418",
+    "BC": "F185.2",
+    "Title": "Von Gott will ich nicht lassen(II)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0419",
+    "BC": "F185.3",
+    "Title": "Von Gott will ich nicht lassen(III)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0420",
+    "BC": "F189.2",
+    "Title": "Warum betrübst du dich, mein Herz(I)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0421",
+    "BC": "F189.1a-b",
+    "Title": "Warum betrübst du dich, mein Herz(II)",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0422",
+    "BC": "F190.1",
+    "Title": "Warum sollt ich mich denn grämen",
+    "Forces": "ch",
+    "Key": "G Mixolydian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0423",
+    "BC": "F191.1",
+    "Title": "Was betrübst du dich, mein Herz",
+    "Forces": "ch",
+    "Key": "G Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0424",
+    "BC": "F192.1",
+    "Title": "Was bist du doch, o Seele, sobetrübet",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0425",
+    "BC": "F195.1",
+    "Title": "Was willst du dich, o meine Seele",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0426",
+    "BC": "F197.1",
+    "Title": "Weltlich Ehr und zeitlich Gut",
+    "Forces": "ch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0427",
+    "BC": "F200.1",
+    "Title": "Wenn ich in Angst und Not",
+    "Forces": "ch",
+    "Key": "E♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0428",
+    "BC": "F201.3",
+    "Title": "Wenn mein Stündlein vorhanden ist(I)",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0429",
+    "BC": "F201.1",
+    "Title": "Wenn mein Stündlein vorhanden ist(II)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0430",
+    "BC": "F201.2",
+    "Title": "Wenn mein Stündlein vorhanden ist(III)",
+    "Forces": "ch",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0431",
+    "BC": "F203.1",
+    "Title": "Wenn wir in höchsten Nöten sein(I)",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0432",
+    "BC": "F203.2",
+    "Title": "Wenn wir in höchsten Nöten sein(II)",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0433",
+    "BC": "F204.1",
+    "Title": "Wer Gott vertraut, hat wohlgebaut",
+    "Forces": "ch",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0434",
+    "BC": "F205.1",
+    "Title": "Wer nur den lieben Gott lässt walten",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0435",
+    "BC": "F207.1",
+    "Title": "Wie bist du, Seele, in mir so gar betrübt",
+    "Forces": "ch",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0436",
+    "BC": "F209.1",
+    "Title": "Wie schön leuchtet der Morgenstern",
+    "Forces": "ch",
+    "Key": "E major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0437",
+    "BC": "F211.1",
+    "Title": "Wir glauben all an einen Gott",
+    "Forces": "ch",
+    "Key": "D Dorian mode",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0438",
+    "BC": "F213.1",
+    "Title": "Wo Gott zum Haus nicht gibt sein Gunst(I)",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0439",
+    "BC": "F274",
+    "Title": "Ach, daß nicht die letzte Stunde",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.831, p.564)"
+  },
+  {
+    "BWV": "0440",
+    "BC": "F229",
+    "Title": "Auf, auf! die rechte Zeit ist hier",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.171, p.114)"
+  },
+  {
+    "BWV": "0441",
+    "BC": "F245",
+    "Title": "Auf, auf! mein Herz, mit Freuden",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.320, p.215)"
+  },
+  {
+    "BWV": "0442",
+    "BC": "F257",
+    "Title": "Beglückter Stand getreuer Seelen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.570, p.386)"
+  },
+  {
+    "BWV": "0443",
+    "BC": "F265",
+    "Title": "Beschränkt, ihr Weisen dieser Welt",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.689, p.473)"
+  },
+  {
+    "BWV": "0444",
+    "BC": "F242",
+    "Title": "Brich entzwei, mein armes Herze",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.303, p.203)"
+  },
+  {
+    "BWV": "0445",
+    "BC": "F247",
+    "Title": "Brunnquell aller Güter",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.355, p.236)"
+  },
+  {
+    "BWV": "0446",
+    "BC": "F220",
+    "Title": "Der lieben Sonne Licht und Pracht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.39, p.24)"
+  },
+  {
+    "BWV": "0447",
+    "BC": "F221",
+    "Title": "Der Tag ist hin, die Sonne gehet nieder",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.40, p.25)"
+  },
+  {
+    "BWV": "0448",
+    "BC": "F222",
+    "Title": "Der Tag mit seinem Lichte",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.43, p.27)"
+  },
+  {
+    "BWV": "0449",
+    "BC": "F249",
+    "Title": "Dich bet ich an, mein höchster Gott",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.396, p.258)"
+  },
+  {
+    "BWV": "0450",
+    "BC": "F235",
+    "Title": "Die bittre Leidenszeit beginnet abermal",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.258, p.170)"
+  },
+  {
+    "BWV": "0451",
+    "BC": "F219",
+    "Title": "Die güldne Sonne",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.13, p.9)"
+  },
+  {
+    "BWV": "0452",
+    "BC": "F250",
+    "Title": "Dir, dir, Jehova, will ich singen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.397, p.259)"
+  },
+  {
+    "BWV": "0453",
+    "BC": "F225",
+    "Title": "Eins ist Not! ach Herr, dies Eine",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.112, p.74)"
+  },
+  {
+    "BWV": "0454",
+    "BC": "F230",
+    "Title": "Ermuntre dich, mein schwacher Geist",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.187, p.125)"
+  },
+  {
+    "BWV": "0455",
+    "BC": "F261",
+    "Title": "Erwürgtes Lamm! das die verwahrten Siegel",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.580, p.396)"
+  },
+  {
+    "BWV": "0456",
+    "BC": "F258",
+    "Title": "Es glänzet der Christen inwendiges Leben",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.572, p.388)"
+  },
+  {
+    "BWV": "0457",
+    "BC": "F275",
+    "Title": "Es ist nun aus mit meinem Leben",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.847, p.574)"
+  },
+  {
+    "BWV": "0458",
+    "BC": "F243",
+    "Title": "Es ist vollbracht! Vergiß ja nicht dies Wort",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.306, p.206)"
+  },
+  {
+    "BWV": "0459",
+    "BC": "F256",
+    "Title": "Es kostet viel, ein Christ zu sein",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.522, p.351)"
+  },
+  {
+    "BWV": "0460",
+    "BC": "F263",
+    "Title": "Gib dich zufrieden und sei stille",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.647, p.444)"
+  },
+  {
+    "BWV": "0461",
+    "BC": "F255",
+    "Title": "Gott lebet noch",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.488, p.325)"
+  },
+  {
+    "BWV": "0462",
+    "BC": "F248",
+    "Title": "Gott, wie groß ist deine Güte",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.360, p.240)"
+  },
+  {
+    "BWV": "0463",
+    "BC": "F223",
+    "Title": "Herr, nicht schicke deine Rache",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.78, p.48)"
+  },
+  {
+    "BWV": "0464",
+    "BC": "F276",
+    "Title": "Ich bin ja, Herr, in deiner Macht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.861, p.584)"
+  },
+  {
+    "BWV": "0465",
+    "BC": "F231",
+    "Title": "Ich freue mich in dir",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.194, p.130)"
+  },
+  {
+    "BWV": "0466",
+    "BC": "F264",
+    "Title": "Ich halte treulich still",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.657, p.451)"
+  },
+  {
+    "BWV": "0467",
+    "BC": "F269",
+    "Title": "Ich laß dich nicht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.734, p.502)"
+  },
+  {
+    "BWV": "0468",
+    "BC": "F270",
+    "Title": "Ich liebe Jesum alle Stund",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.737, p.505)"
+  },
+  {
+    "BWV": "0469",
+    "BC": "F232",
+    "Title": "Ich steh an deiner Krippen hier",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.195, p.131)"
+  },
+  {
+    "BWV": "0470",
+    "BC": "F271",
+    "Title": "Jesu, Jesu, du bist mein",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.741, p.509)"
+  },
+  {
+    "BWV": "0471",
+    "BC": "F228",
+    "Title": "Jesu, deine Liebeswunden",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.139, p.91)"
+  },
+  {
+    "BWV": "0472",
+    "BC": "F226",
+    "Title": "Jesu, meines Glaubens Zier",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.119, p.79)"
+  },
+  {
+    "BWV": "0473",
+    "BC": "F266",
+    "Title": "Jesu, meines Herzens Freud",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.696, p.478)"
+  },
+  {
+    "BWV": "0474",
+    "BC": "F251",
+    "Title": "Jesus ist das schönste Licht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.463, p.303)"
+  },
+  {
+    "BWV": "0475",
+    "BC": "F246",
+    "Title": "Jesus, unser Trost und Leben",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.333, p.222)"
+  },
+  {
+    "BWV": "0476",
+    "BC": "F233",
+    "Title": "Ihr Gestirn, ihr hohen Lüfte",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.197, p.133)"
+  },
+  {
+    "BWV": "0477",
+    "BC": "F278",
+    "Title": "Kein Stündlein geht dahin",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.869, p.591)"
+  },
+  {
+    "BWV": "0478",
+    "BC": "F227",
+    "Title": "Komm, süsser Tod",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.868, p.590)"
+  },
+  {
+    "BWV": "0479",
+    "BC": "F235",
+    "Title": "Kommt, Seelen, dieser Tag",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.936, p.638)"
+  },
+  {
+    "BWV": "0480",
+    "BC": "F286",
+    "Title": "Kommt wieder aus der finstern Gruft",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.938, p.640)"
+  },
+  {
+    "BWV": "0481",
+    "BC": "F236",
+    "Title": "Lasset uns mit Jesu ziehen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.281, p.187)"
+  },
+  {
+    "BWV": "0482",
+    "BC": "F252",
+    "Title": "Liebes Herz, bedenke doch",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.467, p.306)"
+  },
+  {
+    "BWV": "0483",
+    "BC": "F279",
+    "Title": "Liebster Gott, wann werd ich sterben?",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.873, p.595)"
+  },
+  {
+    "BWV": "0484",
+    "BC": "F280",
+    "Title": "Liebster Herr Jesu, wo bleibst du so lange?",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.874, p.596)"
+  },
+  {
+    "BWV": "0485",
+    "BC": "F272",
+    "Title": "Liebster Immanuel, Herzog der Frommen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.761, p.521)"
+  },
+  {
+    "BWV": "0486",
+    "BC": "F227",
+    "Title": "Mein Jesu, dem die Seraphinen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.121, p.81)"
+  },
+  {
+    "BWV": "0487",
+    "BC": "F237",
+    "Title": "Mein Jesu! was für Seelenweh",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.283, p.189)"
+  },
+  {
+    "BWV": "0488",
+    "BC": "F281",
+    "Title": "Meines Lebens letzte Zeit",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.881, p.601)"
+  },
+  {
+    "BWV": "0489",
+    "BC": "F259",
+    "Title": "Nicht so traurig, nicht so sehr",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.574, p.390)"
+  },
+  {
+    "BWV": "0490",
+    "BC": "F267",
+    "Title": "Nur mein Jesus ist mein Leben",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.700, p.481)"
+  },
+  {
+    "BWV": "0491",
+    "BC": "F238",
+    "Title": "O du Liebe meiner Liebe",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.284, p.190)"
+  },
+  {
+    "BWV": "0492",
+    "BC": "F282",
+    "Title": "O finstre Nacht, wann wirst du doch vergehen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.891, p.608)"
+  },
+  {
+    "BWV": "0493",
+    "BC": "F234",
+    "Title": "O Jesulein süß, o Jesulein mild",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.203, p.136)"
+  },
+  {
+    "BWV": "0494",
+    "BC": "F260",
+    "Title": "O liebe Seele, zieh die Sinnen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.575, p.392)"
+  },
+  {
+    "BWV": "0495",
+    "BC": "F283",
+    "Title": "O wie selig seid ihr doch, ihr Frommen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.894, p.611)"
+  },
+  {
+    "BWV": "0496",
+    "BC": "F253",
+    "Title": "Seelenbräutigam, Jesu, Gottes Lamm",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.472, p.312)"
+  },
+  {
+    "BWV": "0497",
+    "BC": "F268",
+    "Title": "Seelenweide, mein Freude",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.710, p.488)"
+  },
+  {
+    "BWV": "0498",
+    "BC": "F239",
+    "Title": "Selig! wer an Jesum denkt",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.292, p.196)"
+  },
+  {
+    "BWV": "0499",
+    "BC": "F240",
+    "Title": "Sei gegrüsset, Jesu gütig",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.293, p.197)"
+  },
+  {
+    "BWV": "0500",
+    "BC": "F241",
+    "Title": "So gehst du nun, mein Jesu, hin",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.296, p.199)"
+  },
+  {
+    "BWV": "0500a",
+    "BC": "—",
+    "Title": "So gehst du nun, mein Jesu, hin",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "alternative version of BWV 500"
+  },
+  {
+    "BWV": "0501",
+    "BC": "F244",
+    "Title": "So gibst du nun, mein Jesu, gute Nacht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.315, p.211)"
+  },
+  {
+    "BWV": "0502",
+    "BC": "F284",
+    "Title": "So wünsch ich mir zu guter Letzt",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.901, p.617)"
+  },
+  {
+    "BWV": "0503",
+    "BC": "F287",
+    "Title": "Steh ich bei meinem Gott",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.945, p.646)"
+  },
+  {
+    "BWV": "0504",
+    "BC": "F475",
+    "Title": "Vergiß mein nicht, daß ich dein nicht vergesse",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.475, p.315)"
+  },
+  {
+    "BWV": "0505",
+    "BC": "F262",
+    "Title": "Vergiß mein nicht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.627, p.430)"
+  },
+  {
+    "BWV": "0506",
+    "BC": "F273",
+    "Title": "Was bist du doch, o Seele, so betrübet",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.779, p.553)"
+  },
+  {
+    "BWV": "0507",
+    "BC": "F224",
+    "Title": "Wo ist mein Schäflein, das ich liebe",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1736",
+    "Genre": "Vocal",
+    "Notes": "Schemelli's Gesang-Buch(No.108, p.69)"
+  },
+  {
+    "BWV": "0508",
+    "BC": "—",
+    "Title": "Bist du bei mir",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "composed byStölzelpossibly arr. by Bach"
+  },
+  {
+    "BWV": "0509",
+    "BC": "—",
+    "Title": "Gedenke doch, mein Geist",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0510",
+    "BC": "—",
+    "Title": "Gib dich zufrieden und sei stille(II)",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0511",
+    "BC": "F214a",
+    "Title": "Gib dich zufrieden und sei stille",
+    "Forces": "v bc",
+    "Key": "G minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0512",
+    "BC": "F214b",
+    "Title": "Gib dich zufrieden und sei stille(II)",
+    "Forces": "v bc",
+    "Key": "E minor",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0513",
+    "BC": "F218",
+    "Title": "O Ewigkeit, du Donnerwort",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0514",
+    "BC": "F216",
+    "Title": "Schaffs mit mir, Gott, nach deinem Willen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0515",
+    "BC": "H02",
+    "Title": "So oft ich meine Tobackspfeife",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "see also BWV 515a"
+  },
+  {
+    "BWV": "0515a",
+    "BC": "H02",
+    "Title": "So oft ich meine Tobackspfeife",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "alternative version of BWV 515"
+  },
+  {
+    "BWV": "0516",
+    "BC": "F215",
+    "Title": "Warum betrübst du dich",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "0517",
+    "BC": "—",
+    "Title": "Wie wohl ist mir, o Freund der Seelen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0518",
+    "BC": "—",
+    "Title": "Willst du dein Herz mir schenken",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0519",
+    "BC": "—",
+    "Title": "Hier lieg’ ich nun",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious"
+  },
+  {
+    "BWV": "0520",
+    "BC": "—",
+    "Title": "Das walt’ mein Gott",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious"
+  },
+  {
+    "BWV": "0521",
+    "BC": "—",
+    "Title": "Gott mein Herz dir Dank zusendet",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious"
+  },
+  {
+    "BWV": "0522",
+    "BC": "—",
+    "Title": "Meine Seele, laß es gehen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious"
+  },
+  {
+    "BWV": "0523",
+    "BC": "—",
+    "Title": "Ich gnüge mich an meinem Stande",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious"
+  },
+  {
+    "BWV": "0524",
+    "BC": "H01",
+    "Title": "Quodlibet(\"Was sind das für große Schlösser\")",
+    "Forces": "4vv bc",
+    "Key": "",
+    "Date": "1708?",
+    "Genre": "Vocal",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0525",
+    "BC": "J01",
+    "Title": "Organ Sonata No.1",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0526",
+    "BC": "J02",
+    "Title": "Organ Sonata No.2",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0527",
+    "BC": "J03",
+    "Title": "Organ Sonata No.3",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": "2nd movt. rev. in BWV 1044"
+  },
+  {
+    "BWV": "0528",
+    "BC": "J04",
+    "Title": "Organ Sonata No.4",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": "partly based on BWV 76"
+  },
+  {
+    "BWV": "0529",
+    "BC": "J05",
+    "Title": "Organ Sonata No.5",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0530",
+    "BC": "J06",
+    "Title": "Organ Sonata No.6",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0531",
+    "BC": "J09",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0532",
+    "BC": "—",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1708-12?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 532a"
+  },
+  {
+    "BWV": "0532a",
+    "BC": "J13J54J70",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 532 No.2"
+  },
+  {
+    "BWV": "0533",
+    "BC": "J18",
+    "Title": "Prelude and Fugue(\"Cathedral\")",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 533a"
+  },
+  {
+    "BWV": "0533a",
+    "BC": "J72",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 533"
+  },
+  {
+    "BWV": "0534",
+    "BC": "J20",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "F minor",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0535",
+    "BC": "J23",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1708–17?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 535a"
+  },
+  {
+    "BWV": "0535a",
+    "BC": "J23",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 535; incomplete"
+  },
+  {
+    "BWV": "0536",
+    "BC": "J24",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1708–17?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 536a"
+  },
+  {
+    "BWV": "0536a",
+    "BC": "—",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 536; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0537",
+    "BC": "J40",
+    "Title": "Fantasia and Fugue",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0538",
+    "BC": "J38",
+    "Title": "Toccata and Fugue(“Dorian”)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1712–17",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0539",
+    "BC": "J15J71",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1720?",
+    "Genre": "Keyboard",
+    "Notes": "Fugue based on part of BWV 1001"
+  },
+  {
+    "BWV": "0540",
+    "BC": "J39J55J73",
+    "Title": "Toccata and Fugue",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1713–31",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0541",
+    "BC": "J22",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1712?, rev. 1724–25",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0542",
+    "BC": "J42J57J67",
+    "Title": "Fantasia and Fugue(“Great”)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1720–25?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0543",
+    "BC": "J42",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": "Fugue based on part of BWV 944. Alternate Prelude to BWV 543a."
+  },
+  {
+    "BWV": "0543a",
+    "BC": "J42",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": "Early Version of BWV 543."
+  },
+  {
+    "BWV": "0544",
+    "BC": "J27",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "B minor",
+    "Date": "1727–31",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0545",
+    "BC": "J51",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1712–17?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 545a, BWV 545b"
+  },
+  {
+    "BWV": "0545a",
+    "BC": "—",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 545"
+  },
+  {
+    "BWV": "0545b",
+    "BC": "—",
+    "Title": "Prelude, Trio and Fugue",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 545; Bach's authorship is uncertain; possibly composed byJohann Tobias Krebs"
+  },
+  {
+    "BWV": "0546",
+    "BC": "J12J53J69",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1723–29?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0547",
+    "BC": "J11",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1725?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0548",
+    "BC": "J19",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1727–31",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0549",
+    "BC": "J14",
+    "Title": "Prelude and Fugue(\"Arnstadt\")",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 549a"
+  },
+  {
+    "BWV": "0549a",
+    "BC": "J14",
+    "Title": "Prelude and Fugue(\"Arnstadt\")",
+    "Forces": "org",
+    "Key": "D Dorian mode",
+    "Date": "1703–07",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 549"
+  },
+  {
+    "BWV": "0550",
+    "BC": "J21",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0551",
+    "BC": "J25",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1707?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0552",
+    "BC": "J16",
+    "Title": "Prelude and Fugue(\"St. Anne\")",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "1739?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0552z553–560",
+    "BC": "J27z",
+    "Title": "Kleine Präludien und Fugen(8):",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0553",
+    "BC": "J28",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0554",
+    "BC": "J29",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0555",
+    "BC": "J30",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0556",
+    "BC": "J31",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0557",
+    "BC": "J32",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0558",
+    "BC": "J33",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0559",
+    "BC": "J34",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0560",
+    "BC": "J35",
+    "Title": "Prelude and Fugue",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0561",
+    "BC": "—",
+    "Title": "Fantasia and Fugue",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composer unidentified"
+  },
+  {
+    "BWV": "0562",
+    "BC": "J41J56",
+    "Title": "Fantasia and Fugue",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1730–45",
+    "Genre": "Keyboard",
+    "Notes": "Fugue incomplete"
+  },
+  {
+    "BWV": "0563",
+    "BC": "J43",
+    "Title": "Fantasia with Imitation",
+    "Forces": "org",
+    "Key": "B minor",
+    "Date": "1707",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0564",
+    "BC": "J36",
+    "Title": "Toccata, Adagio and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1712?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0565",
+    "BC": "J37",
+    "Title": "Toccata and Fugue",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0566",
+    "BC": "J17",
+    "Title": "Toccata and Fugue",
+    "Forces": "org",
+    "Key": "E major",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; 1st version of BWV 566a"
+  },
+  {
+    "BWV": "0566a",
+    "BC": "J17",
+    "Title": "Toccata and Fugue",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; 2nd version of BWV 566"
+  },
+  {
+    "BWV": "0567",
+    "BC": "—",
+    "Title": "Prelude",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "0568",
+    "BC": "J47",
+    "Title": "Prelude",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0569",
+    "BC": "J48",
+    "Title": "Prelude",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0570",
+    "BC": "J49",
+    "Title": "Fantasia",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1705–08?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0571",
+    "BC": "J82",
+    "Title": "Fantasia",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1720?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0572",
+    "BC": "J83",
+    "Title": "Fantasia(\"Pièce d'orgue\")",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1712?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0573",
+    "BC": "J50",
+    "Title": "Fantasia",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1722?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0574",
+    "BC": "J63",
+    "Title": "Fugue on a Theme by Giovanni Legrenzi(Fuge über ein Thema von Giovanni Legrenzi)",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 574a, BWV 574b"
+  },
+  {
+    "BWV": "0574a",
+    "BC": "—",
+    "Title": "Fugue on a Theme by Giovanni Legrenzi(Fuge über ein Thema von Giovanni Legrenzi)",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 574"
+  },
+  {
+    "BWV": "0574b",
+    "BC": "—",
+    "Title": "Fugue on a Theme by Giovanni Legrenzi(Fuge über ein Thema von Giovanni Legrenzi)",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 574"
+  },
+  {
+    "BWV": "0575",
+    "BC": "J60",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1708–17",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0576",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composer unidentified"
+  },
+  {
+    "BWV": "0577",
+    "BC": "J61",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0578",
+    "BC": "J66",
+    "Title": "Fugue(\"Little\")",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1707?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0579",
+    "BC": "J68",
+    "Title": "Fugue on a Theme by Corelli(Fuge über ein Thema von Corelli)",
+    "Forces": "org",
+    "Key": "B minor",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0580",
+    "BC": "J65",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0581",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGottfried August Homilius"
+  },
+  {
+    "BWV": "0582",
+    "BC": "J79",
+    "Title": "Passacaglia",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1708–12?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0583",
+    "BC": "J08",
+    "Title": "Trio",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1723–29?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0584",
+    "BC": "—",
+    "Title": "Trio",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0585",
+    "BC": "—",
+    "Title": "Trio",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Friedrich Fasch"
+  },
+  {
+    "BWV": "0586",
+    "BC": "—",
+    "Title": "Trio",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; based on music byGeorg Philipp Telemann"
+  },
+  {
+    "BWV": "0587",
+    "BC": "—",
+    "Title": "Aria",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; based onLes nationsbyFrançois Couperin"
+  },
+  {
+    "BWV": "0588",
+    "BC": "J80",
+    "Title": "Canzona",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0589",
+    "BC": "J64",
+    "Title": "Alla breve",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1709?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0590",
+    "BC": "J81",
+    "Title": "Pastorale",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "after 1720",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0591",
+    "BC": "J78",
+    "Title": "Kleines harmonisches Labyrinth",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1714",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byJohann David Heinichen"
+  },
+  {
+    "BWV": "0592",
+    "BC": "J88",
+    "Title": "Organ Concerto",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of a lost violin concerto by Prince Johann Ernst of Saxe-Weimar; arr. for hpd as BWV 592a"
+  },
+  {
+    "BWV": "0592a",
+    "BC": "J92",
+    "Title": "Harpsichord Concerto",
+    "Forces": "hpd",
+    "Key": "G major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of BWV 592"
+  },
+  {
+    "BWV": "0593",
+    "BC": "J86",
+    "Title": "Organ Concerto",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of theConcerto for 2 Violins in A minor, RV 522, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0594",
+    "BC": "J84",
+    "Title": "Organ Concerto",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Violin Concerto in D major, RV 208, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0595",
+    "BC": "J87",
+    "Title": "Organ Concerto",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of No.4 of the 6 Violiin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar; see also BWV 987"
+  },
+  {
+    "BWV": "0596",
+    "BC": "J85",
+    "Title": "Organ Concerto",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of theConcerto for 2 Violins and Cello in D minor, RV 565, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0597",
+    "BC": "—",
+    "Title": "Organ Concerto",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "arr. of a concerto by an unidentified composer; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0598",
+    "BC": "—",
+    "Title": "Pedal-Exercitium",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1735?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possbily composed byCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "598a",
+    "BC": "K027a",
+    "Title": "Das Orgel-Büchlein(\"Little Organ Book\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0599",
+    "BC": "K028",
+    "Title": "Nun komm der Heiden Heiland(I)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0600",
+    "BC": "K029",
+    "Title": "Gott, durch deine Güte(\"Gottes Sohn ist kommen\")",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0601",
+    "BC": "K030",
+    "Title": "Herr Christ, der einge Gottessohn(I) (\"Herr Gott, nun sei gepreiset\")",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0602",
+    "BC": "K031",
+    "Title": "Lob sei dem allmächtigen Gott(I)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0603",
+    "BC": "K032",
+    "Title": "Puer natus in Bethlehem",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0604",
+    "BC": "K033",
+    "Title": "Gelobet seist du, Jesu Christ(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0605",
+    "BC": "K034",
+    "Title": "Der Tag, der ist so freudenreich(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0606",
+    "BC": "K035",
+    "Title": "Vom Himmel hoch, da komm ich her(I)",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0607",
+    "BC": "K036",
+    "Title": "Vom Himmel kam der Engel schar",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0608",
+    "BC": "K037",
+    "Title": "In dulci jubilo(I)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0609",
+    "BC": "K038",
+    "Title": "Lobt Gott, ihr Christen, allzugleich(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0610",
+    "BC": "K039",
+    "Title": "Jesu, meine Freude(I)",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0611",
+    "BC": "K040",
+    "Title": "Christum wir sollen loben schon",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0612",
+    "BC": "K041",
+    "Title": "Wir Christenleut(I)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0613",
+    "BC": "K042",
+    "Title": "Helft mir Gottes Güte preisen(I)",
+    "Forces": "org",
+    "Key": "B minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0614",
+    "BC": "K043",
+    "Title": "Das alte Jahr vergangen ist(I)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0615",
+    "BC": "K044",
+    "Title": "In dir ist Freude",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0616",
+    "BC": "K045",
+    "Title": "Mit Fried' und Freud' ich fahr' dahin",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0617",
+    "BC": "K046",
+    "Title": "Herr Gott, nun schleuss den Himmel auf(I)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0618",
+    "BC": "K047",
+    "Title": "O Lamm Gottes, unschuldig(I)",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0619",
+    "BC": "K048",
+    "Title": "Christe, du Lamm Gottes",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0620",
+    "BC": "K049",
+    "Title": "Christus, der uns selig macht(I)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1726",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0620a",
+    "BC": "—",
+    "Title": "Christus, der uns selig macht(II)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1714-16?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0621",
+    "BC": "K050",
+    "Title": "Da Jesus an dem Kreuze stund'",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0622",
+    "BC": "K051",
+    "Title": "O Mensch, bewein' dein' Sünde groß",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0623",
+    "BC": "K052",
+    "Title": "Wir danken dir, Herr Jesu Christ",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0624",
+    "BC": "K053",
+    "Title": "Hilf Gott, daß mir's gelinge",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0625",
+    "BC": "K055",
+    "Title": "Christ lag in Todesbanden(I)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0626",
+    "BC": "K056",
+    "Title": "Jesus Christus, unser Heiland(I)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0627",
+    "BC": "K057",
+    "Title": "Christ ist erstanden(I)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0628",
+    "BC": "K058",
+    "Title": "Erstanden ist der heil'ge Christ(I)",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0629",
+    "BC": "K059",
+    "Title": "Erschienen ist der herrliche Tag",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0630",
+    "BC": "K060",
+    "Title": "Heut triumphieret Gottes Sohn(I)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0630a",
+    "BC": "—",
+    "Title": "Heut triumphieret Gottes Sohn(II)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0631",
+    "BC": "K061",
+    "Title": "Komm, Gott Schöpfer, heiliger Geist(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0631a",
+    "BC": "—",
+    "Title": "Komm, Gott Schöpfer, heiliger Geist(II)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1727–30",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0632",
+    "BC": "K062",
+    "Title": "Herr Jesu Christ, dich zu uns wend(I)",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0633",
+    "BC": "K063b",
+    "Title": "Liebster Jesu, wir sind hier(I)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0634",
+    "BC": "K063a",
+    "Title": "Liebster Jesu, wir sind hier(II)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0635",
+    "BC": "K064",
+    "Title": "Dies sind die heilgen zehn Gebot(I)",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0636",
+    "BC": "K065",
+    "Title": "Vater unser im Himmelreich(I)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0637",
+    "BC": "K066",
+    "Title": "Durch Adams Fall ist ganz verderbt(I)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0637",
+    "BC": "K144",
+    "Title": "Durch Adams Fall ist ganzverderbt(II)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0638",
+    "BC": "K067",
+    "Title": "Es ist das Heil uns kommen her(I)",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0638a",
+    "BC": "—",
+    "Title": "Es ist das Heil uns kommen her(II)",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1710–14",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0639",
+    "BC": "K068",
+    "Title": "Ich ruf zu dir, Herr Jesu Christ(I)",
+    "Forces": "org",
+    "Key": "F minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0640",
+    "BC": "K069",
+    "Title": "Ich dich hab ich gehoffet, Herr",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0641",
+    "BC": "K070",
+    "Title": "Wenn wir in höchsten Nöten sein",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0642",
+    "BC": "K071",
+    "Title": "Wer nur den lieben Gott läßt walten(I)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0643",
+    "BC": "K072",
+    "Title": "Alle Menschen müssen sterben(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0644",
+    "BC": "K073",
+    "Title": "Ach wie nichtig, ach wie flüchtig",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "644a",
+    "BC": "K021a",
+    "Title": "Chorale Preludes (6)(\"Choräle von verschiedener Art\" or \"Schubler Chorales\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0645",
+    "BC": "K022",
+    "Title": "Wachet auf, ruft uns die Stimme",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": "based on movt.IV of BWV 140"
+  },
+  {
+    "BWV": "0646",
+    "BC": "K023",
+    "Title": "Wo soll ich fliehen hin(I)",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0647",
+    "BC": "K024",
+    "Title": "Wer nur den lieben Gott lässt walten(II)",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": "based on movt.IV of BWV 93"
+  },
+  {
+    "BWV": "0648",
+    "BC": "K025",
+    "Title": "Meine Seele erhebet den Herren",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": "based on movt.V of BWV 10"
+  },
+  {
+    "BWV": "0649",
+    "BC": "K026",
+    "Title": "Ach bleib bei uns, Herr Jesu Christ",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": "based on movt.III of BWV 6"
+  },
+  {
+    "BWV": "0650",
+    "BC": "K027",
+    "Title": "Kommst du nun, Jesu, vom Himmel herunter",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": "based on movt.II of BWV 137"
+  },
+  {
+    "BWV": "650a",
+    "BC": "K073a",
+    "Title": "Chorale Preludes (18)(\"Choräle von verschiedener Art\" or \"The Great Eighteen\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0651",
+    "BC": "K074",
+    "Title": "Fantasia super \"Komm, Heiliger Geist\"",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0651a",
+    "BC": "—",
+    "Title": "Fantasia super \"Komm, Heiliger Geist",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0652",
+    "BC": "K075",
+    "Title": "Komm, heiliger Geist(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0652a",
+    "BC": "—",
+    "Title": "Komm, heiliger Geist(II)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0653",
+    "BC": "K076",
+    "Title": "An Wasserflüssen Babylon(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0653a",
+    "BC": "—",
+    "Title": "An Wasserflüssen Babylon(II)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1719?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0653b",
+    "BC": "—",
+    "Title": "An Wasserflüssen Babylon(III)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0654",
+    "BC": "K077",
+    "Title": "Schmücke dich, o liebe Seele(I)",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0654a",
+    "BC": "—",
+    "Title": "Schmücke dich, o liebe Seele(II)",
+    "Forces": "org",
+    "Key": "E♭major",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0655",
+    "BC": "K078",
+    "Title": "Trio super \"Herr Jesu Christ, dich zu uns wend\"(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0655a",
+    "BC": "—",
+    "Title": "Trio super \"Herr Jesu Christ, dich zu uns wend\"(II)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0655b",
+    "BC": "—",
+    "Title": "Trio super \"Herr Jesu Christ, dich zu uns wend\"(III)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0655c",
+    "BC": "—",
+    "Title": "Trio super \"Herr Jesu Christ, dich zu uns wend\"(IV)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0656",
+    "BC": "K079",
+    "Title": "O Lamm Gottes unschuldig(I)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0656a",
+    "BC": "—",
+    "Title": "O Lamm Gottes unschuldig(II)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0657",
+    "BC": "K080",
+    "Title": "Nun danket alle Gott",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0658",
+    "BC": "K081",
+    "Title": "Von Gott will ich nicht lassen(I)",
+    "Forces": "org",
+    "Key": "F minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0658a",
+    "BC": "—",
+    "Title": "Von Gott will ich nicht lassen(II)",
+    "Forces": "org",
+    "Key": "F minor",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0659",
+    "BC": "K082",
+    "Title": "Nun komm der Heiden Heiland(II)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0659a",
+    "BC": "—",
+    "Title": "Nun komm der Heiden Heiland(III)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0660",
+    "BC": "K083",
+    "Title": "Trio super \"Nun komm der Heiden Heiland\"(I)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0660a",
+    "BC": "—",
+    "Title": "Trio super \"Nun komm der Heiden Heiland\"(II)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0660b",
+    "BC": "—",
+    "Title": "Trio super \"Nun komm der Heiden Heiland\"(III)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "0661",
+    "BC": "K084",
+    "Title": "Nun komm der Heiden Heiland(IV)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0661a",
+    "BC": "—",
+    "Title": "Nun komm der Heiden Heiland(V)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0662",
+    "BC": "K085",
+    "Title": "Allein Gott in der Höh sei Ehr(I)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0662a",
+    "BC": "—",
+    "Title": "Allein Gott in der Höh sei Ehr(II)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0663",
+    "BC": "K086",
+    "Title": "Allein Gott in der Höh sei Ehr(III)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0663a",
+    "BC": "—",
+    "Title": "Allein Gott in der Höh sei Ehr(IV)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0664",
+    "BC": "K087",
+    "Title": "Trio super \"Allein Gott in der Höh sei Ehr\"(I)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "1746/47?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0664a",
+    "BC": "—",
+    "Title": "Trio super \"Allein Gott in der Höh sei Ehr\"(II)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0664b",
+    "BC": "—",
+    "Title": "Trio super \"Allein Gott in der Höh sei Ehr\"(V)",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0665",
+    "BC": "K088",
+    "Title": "Jesus Christus, unser Heiland(II)",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0665a",
+    "BC": "—",
+    "Title": "Jesus Christus, unser Heiland(III)",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0666",
+    "BC": "K089",
+    "Title": "Jesus Christus, unser Heiland(IV)",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0666a",
+    "BC": "—",
+    "Title": "Jesus Christus, unser Heiland(V)",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0667",
+    "BC": "K090",
+    "Title": "Komm, Gott Schöpfer, heiliger Geist(III)",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0667a",
+    "BC": "—",
+    "Title": "Komm, Gott Schöpfer, heiliger Geist(IV)",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1749?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0667b",
+    "BC": "—",
+    "Title": "Komm, Gott Schöpfer, heiliger Geist(V)",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0668",
+    "BC": "K091",
+    "Title": "Vor deinen Thron tret ich hiermit(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0668a",
+    "BC": "—",
+    "Title": "Wenn wir in höchsten Nöten sein(II)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1750",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "650a",
+    "BC": "K073a",
+    "Title": "Chorale Preludes(\"Clavier-Übung III\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0669",
+    "BC": "K001",
+    "Title": "Kyrie, Gott Vater in Ewigkeit(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0670",
+    "BC": "K002",
+    "Title": "Christe, aller Welt Trost(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0671",
+    "BC": "K003",
+    "Title": "Kyrie, Gott heiliger Geist(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0672",
+    "BC": "K004",
+    "Title": "Kyrie, Gott Vater in Ewigkeit(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0673",
+    "BC": "K005",
+    "Title": "Christe, aller Welt Trost(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0674",
+    "BC": "K006",
+    "Title": "Kyrie, Gott heiliger Geist(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0675",
+    "BC": "K007",
+    "Title": "Allein Gott in der Höh sei Ehr(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0676",
+    "BC": "K008",
+    "Title": "Allein Gott in der Höh sei Ehr(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0676a",
+    "BC": "—",
+    "Title": "Allein Gott in der Höh sei Ehr",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Variant. Bach's authorship of this work is doubtful"
+  },
+  {
+    "BWV": "0677",
+    "BC": "K009",
+    "Title": "Fughetta super 'Allein Gott in der Höh sei Ehr'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0678",
+    "BC": "K010",
+    "Title": "Dies sind die heilgen zehn Gebot(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0679",
+    "BC": "K011",
+    "Title": "Fughetta super 'Dies sind die heilgen zehn Gebot'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0680",
+    "BC": "K012",
+    "Title": "Wir gläuben all an einen Gott(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0681",
+    "BC": "K013",
+    "Title": "Fughetta super 'Wir gläuben all an einen Gott'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0682",
+    "BC": "K014",
+    "Title": "Vater unser im Himmelreich(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0683",
+    "BC": "K015",
+    "Title": "Vater unser im Himmelreich(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0683a",
+    "BC": "—",
+    "Title": "Vater unser im Himmelreich",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Variant. Bach's authorship of this work is doubtful"
+  },
+  {
+    "BWV": "0684",
+    "BC": "K016",
+    "Title": "Christ, unser Herr, zum Jordan kam(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0685",
+    "BC": "K017",
+    "Title": "Christ, unser Herr, zum Jordan kam(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0686",
+    "BC": "K018",
+    "Title": "Aus tiefer Not schrei ich zu dir(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0687",
+    "BC": "K019",
+    "Title": "Aus tiefer Not schrei ich zu dir(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0688",
+    "BC": "K020",
+    "Title": "Jesus Christus, unser Heiland, der von uns den Zorn Gottes wand(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0689",
+    "BC": "K021",
+    "Title": "Fuga super 'Jesus Christus unser Heiland'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "689a",
+    "BC": "—",
+    "Title": "Chorale Preludes(\"Kirnberger\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0690",
+    "BC": "K127",
+    "Title": "Wer nur den lieben Gott lässt walten(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0691",
+    "BC": "K099",
+    "Title": "Wer nur den lieben Gott lässt walten(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 691"
+  },
+  {
+    "BWV": "0691a",
+    "BC": "—",
+    "Title": "Wer nur den lieben Gott lässt walten(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1749?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 691; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0692",
+    "BC": "—",
+    "Title": "Ach Gott und Herr(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Gottfried Walther"
+  },
+  {
+    "BWV": "0692a",
+    "BC": "—",
+    "Title": "Ach Gott und Herr(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Gottfried Walther"
+  },
+  {
+    "BWV": "0693",
+    "BC": "—",
+    "Title": "Ach Gott und Herr(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Gottfried Walther"
+  },
+  {
+    "BWV": "0694",
+    "BC": "K139",
+    "Title": "Wo soll ich fliehen hin(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0695",
+    "BC": "K136",
+    "Title": "Fantasia super \"Christ lag in Todes Banden\"",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0695a",
+    "BC": "—",
+    "Title": "Fantasia super \"Christ lag in Todes Banden\"",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0696",
+    "BC": "K142",
+    "Title": "Christum wir sollen loben schon",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0697",
+    "BC": "K147",
+    "Title": "Gelobet seist du, Jesu Christ(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0698",
+    "BC": "K149",
+    "Title": "Herr Christ, der einge Gottessohn",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0699",
+    "BC": "K155",
+    "Title": "Nun komm der Heiden Heiland(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0700",
+    "BC": "K156",
+    "Title": "Vom Himmel hoch, da komm ich her(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0701",
+    "BC": "K157",
+    "Title": "Vom Himmel hoch, da komm ich her(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0702",
+    "BC": "K143",
+    "Title": "Das Jesulein soll doch mein Trost",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0703",
+    "BC": "K148",
+    "Title": "Gottes Sohn ist kommen",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0704",
+    "BC": "K153",
+    "Title": "Lob sei dem allmächtigen Gott(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1739–42",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0705",
+    "BC": "—",
+    "Title": "Durch Adams Fall ist ganz verderbt(IV)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1708",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0706",
+    "BC": "K116",
+    "Title": "Liebster Jesu, wir sind hier(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708–14",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0707",
+    "BC": "K137",
+    "Title": "Ich hab mein Sach Gott heimgestellt(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0708",
+    "BC": "K158",
+    "Title": "Ich hab mein Sach Gottheimgestellt(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1731?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0708a",
+    "BC": "—",
+    "Title": "Ich hab mein Sach Gottheimgestellt(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1731?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0709",
+    "BC": "K150",
+    "Title": "Herr Jesu Christ, dich zu unswend(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708–17",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0710",
+    "BC": "—",
+    "Title": "Wir Christenleut habn jetz und Freud",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composer unidentfied"
+  },
+  {
+    "BWV": "0711",
+    "BC": "K140",
+    "Title": "Allein Gott in der Höh sei Ehr(VII)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708–17",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byNicolaus Vetter"
+  },
+  {
+    "BWV": "0712",
+    "BC": "K151",
+    "Title": "In dich hab ich gehoffet, Herr",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0713",
+    "BC": "K138",
+    "Title": "Fantasia super 'Jesu, meine Freude'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0713a",
+    "BC": "—",
+    "Title": "Fantasia super 'Jesu, meine Freude'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "714a",
+    "BC": "—",
+    "Title": "Chorale Preludes",
+    "Forces": "org",
+    "Key": "",
+    "Date": "Various",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0714",
+    "BC": "K172",
+    "Title": "Ach Gott und Herr(\"per canonem\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0715",
+    "BC": "K128",
+    "Title": "Allein Gott in der Höh sei Ehr(VIII)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1727?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0716",
+    "BC": "K141",
+    "Title": "Fuga super 'Allein Gott in der Höh sei Ehr'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0717",
+    "BC": "K106",
+    "Title": "Allein Gott in der Höh sei Ehr(IX)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1710–14",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0718",
+    "BC": "K119",
+    "Title": "Christ lag in Todesbanden(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1712–13",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0719",
+    "BC": "K034",
+    "Title": "Der Tag, der ist so freudenreich(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0720",
+    "BC": "K103",
+    "Title": "Ein feste Burg ist unser Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Michael Bach"
+  },
+  {
+    "BWV": "0721",
+    "BC": "K107",
+    "Title": "Erbarm dich mein, o Herre Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0722",
+    "BC": "K114",
+    "Title": "Gelobet seist du, Jesu Christ(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0722a",
+    "BC": "—",
+    "Title": "Gelobet seist du, Jesu Christ",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0723",
+    "BC": "—",
+    "Title": "Gelobet seist du, Jesu Christ",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Michael Bach"
+  },
+  {
+    "BWV": "0724",
+    "BC": "K029",
+    "Title": "Gott, durch deine Güte(\"Gottes Sohn ist kommen\")",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0725",
+    "BC": "K099",
+    "Title": "Herr Gott, dich loben wir",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0726",
+    "BC": "K130",
+    "Title": "Herr Jesu Christ, dich zu unswend(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1726",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0727",
+    "BC": "K109",
+    "Title": "Herzlich tut mich verlangen",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0728",
+    "BC": "K101",
+    "Title": "Jesus, meine Zuversicht",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0729",
+    "BC": "K115",
+    "Title": "In dulci jubilo(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0729a",
+    "BC": "—",
+    "Title": "In dulci jubilo(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0730",
+    "BC": "K133",
+    "Title": "Liebster Jesu, wir sind hier(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0731",
+    "BC": "K134",
+    "Title": "Liebster Jesu, wir sind hier(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0732",
+    "BC": "K117",
+    "Title": "Lobt Gott, ihr Christen, allzugleich(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0733",
+    "BC": "K120",
+    "Title": "Meine Seele erhebet den Herren(Fuga sopra il Magnificat)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "0734",
+    "BC": "K125",
+    "Title": "Nun freut euch, lieben Christen gmein(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0734a",
+    "BC": "—",
+    "Title": "Es ist gewisslich an der Zeit(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0735",
+    "BC": "K104",
+    "Title": "Fantasia super \"Valet will ich dirgeben\"",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1708–17?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0736",
+    "BC": "K131",
+    "Title": "Valet will ich dir geben",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0737",
+    "BC": "K112",
+    "Title": "Vater unser im Himmelreich(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0738",
+    "BC": "K118",
+    "Title": "Vom Himmel hoch, da komm ich her(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0738a",
+    "BC": "—",
+    "Title": "Vom Himmel hoch, da komm ich her(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0739",
+    "BC": "K097",
+    "Title": "Wie schön leuchtet uns der Morgenstern(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0740",
+    "BC": "—",
+    "Title": "Wir glauben all an einen Gott(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "0741",
+    "BC": "K135",
+    "Title": "Ach Gott vom Himmel sieh darein",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0742",
+    "BC": "K173",
+    "Title": "Ach Herr, mich armen Sünder",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1733?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0743",
+    "BC": "K121",
+    "Title": "Ach, was ist doch unser Leben",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0744",
+    "BC": "K122",
+    "Title": "Auf meinen lieben Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "0745",
+    "BC": "—",
+    "Title": "Aus der Tiefe rufe ich",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; probably composed byCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "0746",
+    "BC": "—",
+    "Title": "Christ ist erstanden(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Caspar Ferdinand Fischer"
+  },
+  {
+    "BWV": "0747",
+    "BC": "K102",
+    "Title": "Christus, der uns selig macht(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1731–40?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0748",
+    "BC": "—",
+    "Title": "Gott der Vater wohn uns bei",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Gottfried Walther; see also BWV 748a"
+  },
+  {
+    "BWV": "0748a",
+    "BC": "—",
+    "Title": "Gott der Vater wohn uns bei",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "variant of BWV 748; spurious; composed byJohann Gottfried Walther"
+  },
+  {
+    "BWV": "0749",
+    "BC": "K195",
+    "Title": "Herr Jesu Christ, dich zu uns wend(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1700?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain, possibly composed byJohann Christoph BachorGeorg Philipp Telemann"
+  },
+  {
+    "BWV": "0750",
+    "BC": "K196",
+    "Title": "Herr Jesu Christ, meins Lebens Licht",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1700?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0751",
+    "BC": "—",
+    "Title": "In dulci jubilo(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Michael Bach"
+  },
+  {
+    "BWV": "0752",
+    "BC": "—",
+    "Title": "Jesu, der du meine Seele",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0753",
+    "BC": "K124",
+    "Title": "Jesu, meine Freude(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0754",
+    "BC": "—",
+    "Title": "Liebster Jesu, wir sind hier(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0755",
+    "BC": "—",
+    "Title": "Nun freut euch, lieben Christen gmein(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0756",
+    "BC": "K197",
+    "Title": "Nun ruhen alle Wälder",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1700?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0757",
+    "BC": "K126",
+    "Title": "O Herre Gott, dein göttlich Wort(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0758",
+    "BC": "K198",
+    "Title": "O Vater, allmächtiger Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0759",
+    "BC": "—",
+    "Title": "Schmücke dich, o liebe SeeleI",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGottfried August Homilius; see also BWV Anh.74"
+  },
+  {
+    "BWV": "0760",
+    "BC": "—",
+    "Title": "Vater unser im Himmelreich(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Böhm"
+  },
+  {
+    "BWV": "0761",
+    "BC": "—",
+    "Title": "Vater unser im Himmelreich(VII)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Böhm"
+  },
+  {
+    "BWV": "0762",
+    "BC": "K113",
+    "Title": "Vater unser im Himmelreich(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0763",
+    "BC": "—",
+    "Title": "Wie schön leuchtet der Morgenstern(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1737?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0764",
+    "BC": "K098",
+    "Title": "Wie schön leuchtet der Morgenstern(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0765",
+    "BC": "K105",
+    "Title": "Wir glauben all an einen Gott(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1718",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0766",
+    "BC": "K094",
+    "Title": "Christ, der du bist der helle Tag",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1700?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0767",
+    "BC": "K095",
+    "Title": "O Gott, du frommer Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0768",
+    "BC": "K096",
+    "Title": "Sei gegrüsset, Jesu gütig",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0769",
+    "BC": "—",
+    "Title": "Vom Himmel hoch, da komm ich her(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1747",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 769a"
+  },
+  {
+    "BWV": "0769a",
+    "BC": "—",
+    "Title": "Vom Himmel hoch, da komm ich her(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1747",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 769"
+  },
+  {
+    "BWV": "0770",
+    "BC": "K093",
+    "Title": "Ach, was soll ich Sünder machen",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0771",
+    "BC": "—",
+    "Title": "Allein Gott in der Höh sei Ehr'",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byNicolaus Vetter"
+  },
+  {
+    "BWV": "0772–786",
+    "BC": "—",
+    "Title": "Inventions(15):",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0772",
+    "BC": "L027",
+    "Title": "Invention No.1",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 772a"
+  },
+  {
+    "BWV": "0772a",
+    "BC": "—",
+    "Title": "Invention No.1",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 772; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0773",
+    "BC": "L028",
+    "Title": "Invention No.2",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0774",
+    "BC": "L029",
+    "Title": "Invention No.3",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0775",
+    "BC": "L030",
+    "Title": "Invention No.4",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0776",
+    "BC": "L031",
+    "Title": "Invention No.5",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0777",
+    "BC": "L032",
+    "Title": "Invention No.6",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0778",
+    "BC": "L033",
+    "Title": "Invention No.7",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0779",
+    "BC": "L034",
+    "Title": "Invention No.8",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0780",
+    "BC": "L035",
+    "Title": "Invention No.9",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0781",
+    "BC": "L036",
+    "Title": "Invention No.10",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0782",
+    "BC": "L037",
+    "Title": "Invention No.11",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0783",
+    "BC": "L038",
+    "Title": "Invention No.12",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0784",
+    "BC": "L039",
+    "Title": "Invention No.13",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0785",
+    "BC": "L040",
+    "Title": "Invention No.14",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0786",
+    "BC": "L041",
+    "Title": "Invention No.15",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0787–801",
+    "BC": "—",
+    "Title": "Sinfonias(15):",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0787",
+    "BC": "L042",
+    "Title": "Sinfonia No.1",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0788",
+    "BC": "L043",
+    "Title": "Sinfonia No.2",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0789",
+    "BC": "L044",
+    "Title": "Sinfonia No.3",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0790",
+    "BC": "L045",
+    "Title": "Sinfonia No.4",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0791",
+    "BC": "L046",
+    "Title": "Sinfonia No.5",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0792",
+    "BC": "L047",
+    "Title": "Sinfonia No.6",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0793",
+    "BC": "L048",
+    "Title": "Sinfonia No.7",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0794",
+    "BC": "L049",
+    "Title": "Sinfonia No.8",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0795",
+    "BC": "L050",
+    "Title": "Sinfonia No.9",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0796",
+    "BC": "L051",
+    "Title": "Sinfonia No.10",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0797",
+    "BC": "L052",
+    "Title": "Sinfonia No.11",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0798",
+    "BC": "L053",
+    "Title": "Sinfonia No.12",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0799",
+    "BC": "L054",
+    "Title": "Sinfonia No.13",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0800",
+    "BC": "L055",
+    "Title": "Sinfonia No.14",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0801",
+    "BC": "L056",
+    "Title": "Sinfonia No.15",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1720–23",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0802",
+    "BC": "J074",
+    "Title": "Duetto No.1",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": "No.23 inClavier-Übung III"
+  },
+  {
+    "BWV": "0803",
+    "BC": "J075",
+    "Title": "Duetto No.2",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": "No.24 inClavier-Übung III"
+  },
+  {
+    "BWV": "0804",
+    "BC": "J076",
+    "Title": "Duetto No.3",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": "No.25 inClavier-Übung III"
+  },
+  {
+    "BWV": "0805",
+    "BC": "J077",
+    "Title": "Duetto No.4",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1739",
+    "Genre": "Keyboard",
+    "Notes": "No.26 inClavier-Übung III"
+  },
+  {
+    "BWV": "0806",
+    "BC": "L013",
+    "Title": "English Suite No.1",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 806a"
+  },
+  {
+    "BWV": "0806a",
+    "BC": "L013",
+    "Title": "English Suite No.1",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1714–17?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 806"
+  },
+  {
+    "BWV": "0807",
+    "BC": "L014",
+    "Title": "English Suite No.2",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0808",
+    "BC": "L015",
+    "Title": "English Suite No.3",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0809",
+    "BC": "L016",
+    "Title": "English Suite No.4",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0810",
+    "BC": "L017",
+    "Title": "English Suite No.5",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0811",
+    "BC": "L018",
+    "Title": "English Suite No.6",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0812",
+    "BC": "L019",
+    "Title": "French Suite No.1",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0813",
+    "BC": "L020",
+    "Title": "French Suite No.2",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 813a"
+  },
+  {
+    "BWV": "0813a",
+    "BC": "L020",
+    "Title": "French Suite No.2",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 813"
+  },
+  {
+    "BWV": "0814",
+    "BC": "L021",
+    "Title": "French Suite No.3",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 814a"
+  },
+  {
+    "BWV": "0814a",
+    "BC": "L021",
+    "Title": "French Suite No.3",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 814"
+  },
+  {
+    "BWV": "0815",
+    "BC": "L022",
+    "Title": "French Suite No.4",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 815a"
+  },
+  {
+    "BWV": "0815a",
+    "BC": "L022",
+    "Title": "French Suite No.4",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 815"
+  },
+  {
+    "BWV": "0816",
+    "BC": "L023",
+    "Title": "French Suite No.5",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0817",
+    "BC": "L024",
+    "Title": "French Suite No.6",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1722–25?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0818",
+    "BC": "L025",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 818"
+  },
+  {
+    "BWV": "0818a",
+    "BC": "L025",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1720–22?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 818"
+  },
+  {
+    "BWV": "0819",
+    "BC": "L026",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1725?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 819"
+  },
+  {
+    "BWV": "0819a",
+    "BC": "L026",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1725–28?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 819"
+  },
+  {
+    "BWV": "0820",
+    "BC": "L173",
+    "Title": "Overture",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0821",
+    "BC": "L169",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0822",
+    "BC": "L168",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0823",
+    "BC": "L167",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0824",
+    "BC": "—",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 32:14)"
+  },
+  {
+    "BWV": "0825",
+    "BC": "L01",
+    "Title": "Partita No.1",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1726",
+    "Genre": "Keyboard",
+    "Notes": "No.1 inClavier-Übung I"
+  },
+  {
+    "BWV": "0826",
+    "BC": "L02",
+    "Title": "Partita No.2",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1727",
+    "Genre": "Keyboard",
+    "Notes": "No.2 inClavier-Übung I"
+  },
+  {
+    "BWV": "0827",
+    "BC": "L03",
+    "Title": "Partita No.3",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1725–27",
+    "Genre": "Keyboard",
+    "Notes": "No.3 inClavier-Übung I"
+  },
+  {
+    "BWV": "0828",
+    "BC": "L04",
+    "Title": "Partita No.4",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1728",
+    "Genre": "Keyboard",
+    "Notes": "No.4 inClavier-Übung I"
+  },
+  {
+    "BWV": "0829",
+    "BC": "L05",
+    "Title": "Partita No.5",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1730",
+    "Genre": "Keyboard",
+    "Notes": "No.5 inClavier-Übung I"
+  },
+  {
+    "BWV": "0830",
+    "BC": "L06",
+    "Title": "Partita No.6",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1725–30",
+    "Genre": "Keyboard",
+    "Notes": "No.6 inClavier-Übung I"
+  },
+  {
+    "BWV": "0831",
+    "BC": "L008",
+    "Title": "Ouverture nach Französischer Art(Overture in the French Style)",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1735",
+    "Genre": "Keyboard",
+    "Notes": "2nd version of BWV 831a; No.2 inClavier-Übung II"
+  },
+  {
+    "BWV": "0831a",
+    "BC": "L008",
+    "Title": "Ouverture nach Französischer Art(Overture in the French Style)",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1733",
+    "Genre": "Keyboard",
+    "Notes": "1st version of BWV 831"
+  },
+  {
+    "BWV": "0832",
+    "BC": "L174",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0833",
+    "BC": "L172",
+    "Title": "Praeludium et Partita dei Tuono Terzo",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1708–14?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byBernardo Pasquini"
+  },
+  {
+    "BWV": "0834",
+    "BC": "—",
+    "Title": "Allemande",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0835",
+    "BC": "—",
+    "Title": "Allemande",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Philipp Kirnberger"
+  },
+  {
+    "BWV": "0836",
+    "BC": "A040",
+    "Title": "Allemande",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720–22",
+    "Genre": "Keyboard",
+    "Notes": "composed withWilhelm Friedemann Bach"
+  },
+  {
+    "BWV": "0837",
+    "BC": "A041",
+    "Title": "Allemande",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720–22",
+    "Genre": "Keyboard",
+    "Notes": "composed withWilhelm Friedemann Bach; incomplete"
+  },
+  {
+    "BWV": "0838",
+    "BC": "—",
+    "Title": "Allemande and Courante",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byChristoph Graupner(GWV 849/2–3)"
+  },
+  {
+    "BWV": "0839",
+    "BC": "—",
+    "Title": "Sarabande",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1735?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0840",
+    "BC": "—",
+    "Title": "Courante",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 32:13)"
+  },
+  {
+    "BWV": "0841",
+    "BC": "L176/1",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "Part of the3 Minuets"
+  },
+  {
+    "BWV": "0842",
+    "BC": "L176/2",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "Part of the3 Minuets"
+  },
+  {
+    "BWV": "0843",
+    "BC": "L176/3",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "Part of the3 Minuets"
+  },
+  {
+    "BWV": "0844",
+    "BC": "—",
+    "Title": "Scherzo",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach; see also BWV 844a"
+  },
+  {
+    "BWV": "0844a",
+    "BC": "—",
+    "Title": "Scherzo",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 844; Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
+  },
+  {
+    "BWV": "0845",
+    "BC": "—",
+    "Title": "Gigue",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0846-869",
+    "BC": "—",
+    "Title": "Das wohltemperierte Klavier I(The Well-Tempered Clavier, Part I)",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0846",
+    "BC": "L080",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 846a"
+  },
+  {
+    "BWV": "0846a",
+    "BC": "L080",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 846"
+  },
+  {
+    "BWV": "0847",
+    "BC": "L081",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 847a"
+  },
+  {
+    "BWV": "0847a",
+    "BC": "L081",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 847"
+  },
+  {
+    "BWV": "0848",
+    "BC": "L082",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C♯major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 848a"
+  },
+  {
+    "BWV": "0848a",
+    "BC": "L082",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "C♯major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 848"
+  },
+  {
+    "BWV": "0849",
+    "BC": "L083",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C♯minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 849a"
+  },
+  {
+    "BWV": "0849a",
+    "BC": "L083",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "C♯minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 849"
+  },
+  {
+    "BWV": "0850",
+    "BC": "L084",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 850a"
+  },
+  {
+    "BWV": "0850a",
+    "BC": "L084",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 850"
+  },
+  {
+    "BWV": "0851",
+    "BC": "L085",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 851a"
+  },
+  {
+    "BWV": "0851a",
+    "BC": "L085",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 851"
+  },
+  {
+    "BWV": "0852",
+    "BC": "L086",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 852a"
+  },
+  {
+    "BWV": "0852a",
+    "BC": "L086",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 852"
+  },
+  {
+    "BWV": "0853",
+    "BC": "L087",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E♭minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 853a"
+  },
+  {
+    "BWV": "0853a",
+    "BC": "L087",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "E♭minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 853"
+  },
+  {
+    "BWV": "0854",
+    "BC": "L088",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 854a"
+  },
+  {
+    "BWV": "0854a",
+    "BC": "L088",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 854"
+  },
+  {
+    "BWV": "0855",
+    "BC": "L089",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 855a"
+  },
+  {
+    "BWV": "0855a",
+    "BC": "L089",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 855"
+  },
+  {
+    "BWV": "0856",
+    "BC": "L090",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 856a"
+  },
+  {
+    "BWV": "0856a",
+    "BC": "L090",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 856"
+  },
+  {
+    "BWV": "0857",
+    "BC": "L091",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 857a"
+  },
+  {
+    "BWV": "0857a",
+    "BC": "L091",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 857"
+  },
+  {
+    "BWV": "0858",
+    "BC": "L092",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F♯major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 858a"
+  },
+  {
+    "BWV": "0858a",
+    "BC": "L092",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "F♯major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 858"
+  },
+  {
+    "BWV": "0859",
+    "BC": "L093",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F♯minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 859a"
+  },
+  {
+    "BWV": "0859a",
+    "BC": "L093",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "F♯minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 859"
+  },
+  {
+    "BWV": "0860",
+    "BC": "L094",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 860a"
+  },
+  {
+    "BWV": "0860a",
+    "BC": "L094",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 860"
+  },
+  {
+    "BWV": "0861",
+    "BC": "L095",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 861a"
+  },
+  {
+    "BWV": "0861a",
+    "BC": "L095",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 861"
+  },
+  {
+    "BWV": "0862",
+    "BC": "L096",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A♭major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 862a"
+  },
+  {
+    "BWV": "0862a",
+    "BC": "L096",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "A♭major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 862"
+  },
+  {
+    "BWV": "0863",
+    "BC": "L097",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "G♯minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 863a"
+  },
+  {
+    "BWV": "0863a",
+    "BC": "L097",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "G♯minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 863"
+  },
+  {
+    "BWV": "0864",
+    "BC": "L098",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 864a"
+  },
+  {
+    "BWV": "0864a",
+    "BC": "L098",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 864"
+  },
+  {
+    "BWV": "0865",
+    "BC": "L099",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 865a"
+  },
+  {
+    "BWV": "0865a",
+    "BC": "L099",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 865"
+  },
+  {
+    "BWV": "0866",
+    "BC": "L100",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 866a"
+  },
+  {
+    "BWV": "0866a",
+    "BC": "L100",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 866"
+  },
+  {
+    "BWV": "0867",
+    "BC": "L101",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B♭minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 867a"
+  },
+  {
+    "BWV": "0867a",
+    "BC": "L101",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "B♭minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 867"
+  },
+  {
+    "BWV": "0868",
+    "BC": "L102",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 868a"
+  },
+  {
+    "BWV": "0868a",
+    "BC": "L102",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "B major",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 868"
+  },
+  {
+    "BWV": "0869",
+    "BC": "L103",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 869a"
+  },
+  {
+    "BWV": "0869a",
+    "BC": "L103",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 869"
+  },
+  {
+    "BWV": "0870-893",
+    "BC": "—",
+    "Title": "Das wohltemperierte Klavier II(The Well-Tempered Clavier, Part II)",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0870",
+    "BC": "L104",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 870a, 870b"
+  },
+  {
+    "BWV": "0870a",
+    "BC": "L104",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 870"
+  },
+  {
+    "BWV": "0870b",
+    "BC": "L104",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 870"
+  },
+  {
+    "BWV": "0871",
+    "BC": "L105",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0872",
+    "BC": "L106",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C♯major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 872a"
+  },
+  {
+    "BWV": "0872a",
+    "BC": "L106",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 872"
+  },
+  {
+    "BWV": "0873",
+    "BC": "L107",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "C♯minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0874",
+    "BC": "L108",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0875",
+    "BC": "L109",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 875a"
+  },
+  {
+    "BWV": "0875a",
+    "BC": "L109",
+    "Title": "Praeambulum",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 875"
+  },
+  {
+    "BWV": "0876",
+    "BC": "L110",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0877",
+    "BC": "L111",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "D♯minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0878",
+    "BC": "L112",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0879",
+    "BC": "L113",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0880",
+    "BC": "L114",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0881",
+    "BC": "L115",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0882",
+    "BC": "L116",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F♯major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0883",
+    "BC": "L117",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "F♯minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0884",
+    "BC": "L118",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0885",
+    "BC": "L119",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0886",
+    "BC": "L120",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A♭major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0887",
+    "BC": "L121",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "G♯minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0888",
+    "BC": "L122",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0889",
+    "BC": "L123",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0890",
+    "BC": "L124",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0891",
+    "BC": "L125",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B♭minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0892",
+    "BC": "L126",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B major",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0893",
+    "BC": "L127",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1740",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0894",
+    "BC": "L130",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1715–25",
+    "Genre": "Keyboard",
+    "Notes": "rev. in BWV 1044"
+  },
+  {
+    "BWV": "0895",
+    "BC": "L129",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1709",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0896",
+    "BC": "L128",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0897",
+    "BC": "—",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "prelude composed byCornelius Heinrich Dretzel; composer of fugue uncertain"
+  },
+  {
+    "BWV": "0898",
+    "BC": "—",
+    "Title": "Prelude and Fugue(on the name of \"B-A-C-H\")",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byJohann Christian Kittel"
+  },
+  {
+    "BWV": "0899",
+    "BC": "—",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1725–26?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0900",
+    "BC": "L077",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1725–26?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0901",
+    "BC": "L078",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0902",
+    "BC": "L079",
+    "Title": "Prelude and Fughetta",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 902/1a"
+  },
+  {
+    "BWV": "0902/1a",
+    "BC": "—",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of prelude from BWV 902"
+  },
+  {
+    "BWV": "0903",
+    "BC": "L134",
+    "Title": "Chromatic Fantasia",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 903a"
+  },
+  {
+    "BWV": "0903a",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 903"
+  },
+  {
+    "BWV": "0904",
+    "BC": "L136",
+    "Title": "Fantasia and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1725?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0905",
+    "BC": "—",
+    "Title": "Fantasia and Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0906",
+    "BC": "L133L138",
+    "Title": "Fantasia and Fugue",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1704?",
+    "Genre": "Keyboard",
+    "Notes": "fugue incompete"
+  },
+  {
+    "BWV": "0907",
+    "BC": "—",
+    "Title": "Fantasia and Fughetta",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGottfried Kirchhoff"
+  },
+  {
+    "BWV": "0908",
+    "BC": "—",
+    "Title": "Fantasia and Fughetta",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGottfried Kirchhoff"
+  },
+  {
+    "BWV": "0909",
+    "BC": "—",
+    "Title": "Concerto and Fugue",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1703",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0910",
+    "BC": "L146",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "F♯minor",
+    "Date": "1712",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0911",
+    "BC": "L142",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0912",
+    "BC": "L143",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 912a"
+  },
+  {
+    "BWV": "0912a",
+    "BC": "L143",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": "early version of the Adagio from BWV 912"
+  },
+  {
+    "BWV": "0913",
+    "BC": "L144",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 913a"
+  },
+  {
+    "BWV": "0913a",
+    "BC": "L144",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 913"
+  },
+  {
+    "BWV": "0914",
+    "BC": "L145L163",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1710",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0915",
+    "BC": "L148",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1710",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0916",
+    "BC": "L147",
+    "Title": "Toccata",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0917",
+    "BC": "L140",
+    "Title": "Fantasia",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1710?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0918",
+    "BC": "L139",
+    "Title": "Fantasia(Fantasia über ein rondo)",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1740?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0919",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; byJohann Bernhard Bach"
+  },
+  {
+    "BWV": "0920",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0921",
+    "BC": "J44J52",
+    "Title": "Prelude(Fantasia)",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1713",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0922",
+    "BC": "L141",
+    "Title": "Prelude(Fantasia)",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1710–14?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0923",
+    "BC": "L131",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed by Wilhelm Heironymous Pachelbel; see also BWV 923a"
+  },
+  {
+    "BWV": "0923a",
+    "BC": "L131",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 923; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0924–932",
+    "BC": "—",
+    "Title": "Kleine Präluden(9):",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0924",
+    "BC": "L057",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "see also BWV 924a"
+  },
+  {
+    "BWV": "0924a",
+    "BC": "L057",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 924; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0925",
+    "BC": "—",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
+  },
+  {
+    "BWV": "0926",
+    "BC": "L058",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0927",
+    "BC": "L059",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0928",
+    "BC": "L060",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0929",
+    "BC": "L061",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0930",
+    "BC": "L062",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0931",
+    "BC": "—",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
+  },
+  {
+    "BWV": "0932",
+    "BC": "L063",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1720",
+    "Genre": "Keyboard",
+    "Notes": "incomplete; Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
+  },
+  {
+    "BWV": "0933–938",
+    "BC": "—",
+    "Title": "Kleine Präluden(6):",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0933",
+    "BC": "L064",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0934",
+    "BC": "L065",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0935",
+    "BC": "L066",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0936",
+    "BC": "L067",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0937",
+    "BC": "L068",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0938",
+    "BC": "L069",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0939–943",
+    "BC": "—",
+    "Title": "Kleine Präluden(5):",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0939",
+    "BC": "L070",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0940",
+    "BC": "L071",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0941",
+    "BC": "L072",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1717",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0942",
+    "BC": "L073",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1717?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0943",
+    "BC": "L074",
+    "Title": "Prelude",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1703–07",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0944",
+    "BC": "L135",
+    "Title": "Fantasia and Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": "Fugue rev. in BWV 543"
+  },
+  {
+    "BWV": "0945",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1695–1700?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain (possibly composed byChristoph Graupner"
+  },
+  {
+    "BWV": "0946",
+    "BC": "L160",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1708?",
+    "Genre": "Keyboard",
+    "Notes": "on a theme byTomaso Albinoni"
+  },
+  {
+    "BWV": "0947",
+    "BC": "L157",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0948",
+    "BC": "L151",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1727?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0949",
+    "BC": "L154",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1715?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0950",
+    "BC": "L161",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "1710",
+    "Genre": "Keyboard",
+    "Notes": "on a theme byTomaso Albinoni"
+  },
+  {
+    "BWV": "0951",
+    "BC": "L162",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1712",
+    "Genre": "Keyboard",
+    "Notes": "on a theme byTomaso Albinoni; see also BWV 951a"
+  },
+  {
+    "BWV": "0951a",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1712",
+    "Genre": "Keyboard",
+    "Notes": "alternative version of BWV 951"
+  },
+  {
+    "BWV": "0952",
+    "BC": "L150",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0953",
+    "BC": "L149",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1723?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0954",
+    "BC": "L163",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1730?",
+    "Genre": "Keyboard",
+    "Notes": "on a theme byJohann Adam Reincken"
+  },
+  {
+    "BWV": "0955",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "previously thought to have been arr. from a work byJohann Christoph Erselius; see also BWV 955a"
+  },
+  {
+    "BWV": "0955a",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "early variant of BWV 955"
+  },
+  {
+    "BWV": "0956",
+    "BC": "L152",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0957",
+    "BC": "K191",
+    "Title": "Machs mit mir, Gott, nach deiner Güt",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "previously believed to be a fugue hpd"
+  },
+  {
+    "BWV": "0958",
+    "BC": "L155",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0959",
+    "BC": "L156",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0960",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0961",
+    "BC": "L158",
+    "Title": "Fughetta",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1712?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0962",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "1783",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Georg Albrechtsberger"
+  },
+  {
+    "BWV": "0963",
+    "BC": "L182",
+    "Title": "Sonata",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1704?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0964",
+    "BC": "L184",
+    "Title": "Sonata",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "arr. of BWV 1003"
+  },
+  {
+    "BWV": "0965",
+    "BC": "L187",
+    "Title": "Sonata",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Sonata No.1 fromHortus MusicusbyJohann Adam Reincken"
+  },
+  {
+    "BWV": "0966",
+    "BC": "L186",
+    "Title": "Sonata",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Sonata No.3 fromHortus MusicusbyJohann Adam Reincken"
+  },
+  {
+    "BWV": "0967",
+    "BC": "L183",
+    "Title": "Sonata",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1705?",
+    "Genre": "Keyboard",
+    "Notes": "arr. of an unidentified work by an unknown composer"
+  },
+  {
+    "BWV": "0968",
+    "BC": "L185",
+    "Title": "Adagio",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1720?",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the 1st movt. of BWV 1005"
+  },
+  {
+    "BWV": "0969",
+    "BC": "—",
+    "Title": "Andante",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "0970",
+    "BC": "—",
+    "Title": "Presto",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byWilhelm Friedemann Bach(F.25/2)"
+  },
+  {
+    "BWV": "0971",
+    "BC": "L007",
+    "Title": "Italienisches Konzert(Italian Concerto)",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1735",
+    "Genre": "Keyboard",
+    "Notes": "No.1 inClavier-ÜbungII"
+  },
+  {
+    "BWV": "0972–987",
+    "BC": "—",
+    "Title": "Konzerte nach verschiedenen Meistem(Concertos by Various Maestros) (16):",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arrs. of works by other composers"
+  },
+  {
+    "BWV": "0972",
+    "BC": "L189",
+    "Title": "Concerto No.1",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "Revised version, arr. of theViolin Concerto in D major, RV 230, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0972a",
+    "BC": "—",
+    "Title": "Concerto No.1",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1711",
+    "Genre": "Keyboard",
+    "Notes": "Early version, arr. of theViolin Concerto in D major, RV 230, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0973",
+    "BC": "L191",
+    "Title": "Concerto No.2",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of theViolin Concerto in G major, RV 299, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0974",
+    "BC": "L194",
+    "Title": "Concerto No.3",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of theOboe Concerto in D minorbyAlessandro Marcello"
+  },
+  {
+    "BWV": "0975",
+    "BC": "L193",
+    "Title": "Concerto No.4",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Violin Concerto in G minor, RV 316, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0976",
+    "BC": "L188",
+    "Title": "Concerto No.5",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of theViolin Concerto in E major, RV 265, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0977",
+    "BC": "L202",
+    "Title": "Concerto No.6",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "source unidentified"
+  },
+  {
+    "BWV": "0978",
+    "BC": "L190",
+    "Title": "Concerto No.7",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of theViolin Concerto in G major, RV 310, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0979",
+    "BC": "L196",
+    "Title": "Concerto No.8",
+    "Forces": "kbd",
+    "Key": "B minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of a Violin Concerto in D minor byGiuseppe Torelli"
+  },
+  {
+    "BWV": "0980",
+    "BC": "L192",
+    "Title": "Concerto No.9",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Violin Concerto in B♭minor, RV 381, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "0981",
+    "BC": "L195",
+    "Title": "Concerto No.10",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Violin Concerto in C minor, Op.1 No.2, byBenedetto Marcello"
+  },
+  {
+    "BWV": "0982",
+    "BC": "L200",
+    "Title": "Concerto No.11",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of No.1 of the 6 Violin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar"
+  },
+  {
+    "BWV": "0983",
+    "BC": "L204",
+    "Title": "Concerto No.12",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "source unidentified"
+  },
+  {
+    "BWV": "0984",
+    "BC": "L197",
+    "Title": "Concerto No.13",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of a lost concerto by Prince Johann Ernst of Saxe-Weimar"
+  },
+  {
+    "BWV": "0985",
+    "BC": "L201",
+    "Title": "Concerto No.14",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of the Violin Concerto in G minor, TWV 51:g21, byGeorg Philipp Telemann"
+  },
+  {
+    "BWV": "0986",
+    "BC": "L203",
+    "Title": "Concerto No.15",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "source unidentified"
+  },
+  {
+    "BWV": "0987",
+    "BC": "L198",
+    "Title": "Concerto No.16",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1713–14",
+    "Genre": "Keyboard",
+    "Notes": "arr. of No.4 of the 6 Violin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar; see also BWV 595"
+  },
+  {
+    "BWV": "0988",
+    "BC": "L009",
+    "Title": "Goldberg-Variationen(Goldberg Variations)",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1741–42",
+    "Genre": "Keyboard",
+    "Notes": "published inClavier-ÜbungIV"
+  },
+  {
+    "BWV": "0989",
+    "BC": "L179",
+    "Title": "Aria variata(\"alla maniera italiana\")",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1714?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0990",
+    "BC": "—",
+    "Title": "Sarabande con partite",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0991",
+    "BC": "—",
+    "Title": "Air with Variations",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1722",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "0992",
+    "BC": "L181",
+    "Title": "Capriccio(\"sopra la lotananza delsuo fratello dilettissimo\")",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1704?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0993",
+    "BC": "L180",
+    "Title": "Capriccio(\"in honorem Johann Christoph Bachii\")",
+    "Forces": "kbd",
+    "Key": "E major",
+    "Date": "1721?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0994",
+    "BC": "Q1",
+    "Title": "Applicatio",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "1720–21",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "0995",
+    "BC": "—",
+    "Title": "Suite",
+    "Forces": "lute",
+    "Key": "G minor",
+    "Date": "1727–31?",
+    "Genre": "Chamber",
+    "Notes": "arr. of BWV 1011"
+  },
+  {
+    "BWV": "0996",
+    "BC": "L166",
+    "Title": "Suite",
+    "Forces": "lute/hpd",
+    "Key": "E minor",
+    "Date": "1712–17?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "0997",
+    "BC": "L170",
+    "Title": "Suite",
+    "Forces": "lute/hpd",
+    "Key": "C minor",
+    "Date": "1740?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "0998",
+    "BC": "L132",
+    "Title": "Prelude, Fugue and Allegro",
+    "Forces": "lute/kbd",
+    "Key": "E♭major",
+    "Date": "1740–45?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "0999",
+    "BC": "L175",
+    "Title": "Prelude",
+    "Forces": "lute",
+    "Key": "C minor",
+    "Date": "1725?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1000",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "lute",
+    "Key": "G minor",
+    "Date": "1720?",
+    "Genre": "Chamber",
+    "Notes": "arr. of 2nd movt. from BWV 1001"
+  },
+  {
+    "BWV": "1001-1006",
+    "BC": "—",
+    "Title": "Violin Sonatas and Partitas(6):",
+    "Forces": "vn",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "(link to complete collections of all 6 sonatas and partitas)"
+  },
+  {
+    "BWV": "1001",
+    "BC": "—",
+    "Title": "Violin Sonata No.1",
+    "Forces": "vn",
+    "Key": "G minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "partly rev. in BWV 539; 2nd movt. arr. for lute as BWV 1000"
+  },
+  {
+    "BWV": "1002",
+    "BC": "—",
+    "Title": "Violin Partita No.1",
+    "Forces": "vn",
+    "Key": "B minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1003",
+    "BC": "—",
+    "Title": "Violin Sonata No.2",
+    "Forces": "vn",
+    "Key": "A minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "arr. for kbd as BWV 964"
+  },
+  {
+    "BWV": "1004",
+    "BC": "—",
+    "Title": "Violin Partita No.2",
+    "Forces": "vn",
+    "Key": "D minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1005",
+    "BC": "—",
+    "Title": "Violin Sonata No.3",
+    "Forces": "vn",
+    "Key": "C major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "1st movt. arr. for kbd as BWV 968"
+  },
+  {
+    "BWV": "1006",
+    "BC": "—",
+    "Title": "Violin Partita No.3",
+    "Forces": "vn",
+    "Key": "E major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "arr. for lute as BWV 1006a; 1st movt. arr. for org orch as Sinfonia of BWV 29"
+  },
+  {
+    "BWV": "1006a",
+    "BC": "L171",
+    "Title": "Suite",
+    "Forces": "lute",
+    "Key": "E major",
+    "Date": "1736–37",
+    "Genre": "Chamber",
+    "Notes": "arr. of BWV 1006"
+  },
+  {
+    "BWV": "1007-1012",
+    "BC": "—",
+    "Title": "Cello Suites(6):",
+    "Forces": "vc",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "(link to complete collections of all 6 suites)"
+  },
+  {
+    "BWV": "1007",
+    "BC": "—",
+    "Title": "Cello Suite No.1",
+    "Forces": "vc",
+    "Key": "G major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1008",
+    "BC": "—",
+    "Title": "Cello Suite No.2",
+    "Forces": "vc",
+    "Key": "D minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1009",
+    "BC": "—",
+    "Title": "Cello Suite No.3",
+    "Forces": "vc",
+    "Key": "C major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1010",
+    "BC": "—",
+    "Title": "Cello Suite No.4",
+    "Forces": "vc",
+    "Key": "E♭major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1011",
+    "BC": "—",
+    "Title": "Cello Suite No.5",
+    "Forces": "vc",
+    "Key": "C minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "arr. for lute as BWV 995"
+  },
+  {
+    "BWV": "1012",
+    "BC": "—",
+    "Title": "Cello Suite No.6",
+    "Forces": "vc",
+    "Key": "D major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1013",
+    "BC": "—",
+    "Title": "Partita",
+    "Forces": "fl",
+    "Key": "A minor",
+    "Date": "1722–23",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1014–1019",
+    "BC": "—",
+    "Title": "Violin Sonatas(6):",
+    "Forces": "vn kbd",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1014",
+    "BC": "—",
+    "Title": "Sonata No.1",
+    "Forces": "vn kbd",
+    "Key": "B minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1015",
+    "BC": "—",
+    "Title": "Sonata No.2",
+    "Forces": "vn kbd",
+    "Key": "A major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1016",
+    "BC": "—",
+    "Title": "Sonata No.3",
+    "Forces": "vn kbd",
+    "Key": "E major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1017",
+    "BC": "—",
+    "Title": "Sonata No.4",
+    "Forces": "vn kbd",
+    "Key": "C minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1018",
+    "BC": "—",
+    "Title": "Sonata No.5",
+    "Forces": "vn kbd",
+    "Key": "F minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "see also BWV 1018a"
+  },
+  {
+    "BWV": "1018a",
+    "BC": "—",
+    "Title": "Sonata No.5",
+    "Forces": "vn kbd",
+    "Key": "F minor",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "alternative version of BWV 1018, 3rd movt."
+  },
+  {
+    "BWV": "1019",
+    "BC": "—",
+    "Title": "Sonata No.6",
+    "Forces": "vn kbd",
+    "Key": "G major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "see also BWV 1019a"
+  },
+  {
+    "BWV": "1019a",
+    "BC": "—",
+    "Title": "Sonata No.6",
+    "Forces": "vn kbd",
+    "Key": "G major",
+    "Date": "1720",
+    "Genre": "Chamber",
+    "Notes": "alternative version of BWV 1019"
+  },
+  {
+    "BWV": "1020",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn/fl kbd",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.542.5)"
+  },
+  {
+    "BWV": "1021",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn bc",
+    "Key": "G major",
+    "Date": "1730–34?",
+    "Genre": "Chamber",
+    "Notes": "shares the bc part with BWV 1022 and BWV 1038"
+  },
+  {
+    "BWV": "1022",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn kbd",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": "arr. of BWV 1038; Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "1023",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn bc",
+    "Key": "E minor",
+    "Date": "1714–17?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1024",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn bc",
+    "Key": "C minor",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1025",
+    "BC": "—",
+    "Title": "Suite",
+    "Forces": "vn kbd",
+    "Key": "A major",
+    "Date": "1740",
+    "Genre": "Chamber",
+    "Notes": "arr. of the Lute Sonata in A major, SC 47, by Silvius Leopold Weiss"
+  },
+  {
+    "BWV": "1026",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "vn bc",
+    "Key": "G minor",
+    "Date": "before 1712",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1027–1029",
+    "BC": "—",
+    "Title": "Sonatas for Viola da Gamba and Harpsichord(3):",
+    "Forces": "viol hpd",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1027",
+    "BC": "—",
+    "Title": "Sonata No.1",
+    "Forces": "viol hpd",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": "arr. of BWV 1039; see also BWV 1027a"
+  },
+  {
+    "BWV": "1027a",
+    "BC": "—",
+    "Title": "Trios(3)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "arrs. of movts. 1, 2 and 4 from BWV 1027a; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1028",
+    "BC": "—",
+    "Title": "Sonata No.2",
+    "Forces": "viol hpd",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1029",
+    "BC": "—",
+    "Title": "Sonata No.3",
+    "Forces": "viol hpd",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1030",
+    "BC": "—",
+    "Title": "Flute Sonata",
+    "Forces": "fl hpd",
+    "Key": "B minor",
+    "Date": "1736–37",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1030b",
+    "BC": "—",
+    "Title": "Oboe Sonata",
+    "Forces": "ob hpd",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1031",
+    "BC": "—",
+    "Title": "Flute Sonata",
+    "Forces": "fl hpd",
+    "Key": "E♭major",
+    "Date": "1730–34?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1032",
+    "BC": "—",
+    "Title": "Flute Sonata",
+    "Forces": "fl hpd",
+    "Key": "A major",
+    "Date": "1736?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1033",
+    "BC": "—",
+    "Title": "Flute Sonata",
+    "Forces": "fl bc",
+    "Key": "C major",
+    "Date": "1736",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1034",
+    "BC": "—",
+    "Title": "Flute Sonata",
+    "Forces": "fl bc",
+    "Key": "E minor",
+    "Date": "1724",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1035",
+    "BC": "—",
+    "Title": "Flute Sonata",
+    "Forces": "fl bc",
+    "Key": "E major",
+    "Date": "1741",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1036",
+    "BC": "—",
+    "Title": "Trio Sonata",
+    "Forces": "2vn bc",
+    "Key": "D minor",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.145, H.569)"
+  },
+  {
+    "BWV": "1037",
+    "BC": "—",
+    "Title": "Trio Sonata",
+    "Forces": "2vn bc",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byJohann Gottlieb Goldberg"
+  },
+  {
+    "BWV": "1038",
+    "BC": "—",
+    "Title": "Trio Sonata",
+    "Forces": "fl vn bc",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": "bc part virtually identical to that of BWV 1021; Bach's authorship for upper two voices uncertain; possibly composed byCarl Philipp Emanuel Bach(H.590.5); arr. for vn hpd as BWV 1022"
+  },
+  {
+    "BWV": "1039",
+    "BC": "—",
+    "Title": "Trio Sonata",
+    "Forces": "2fl bc",
+    "Key": "G major",
+    "Date": "1736–41?",
+    "Genre": "Chamber",
+    "Notes": "arr. for viol hpd as BWV 1027"
+  },
+  {
+    "BWV": "1040",
+    "BC": "—",
+    "Title": "Trio Sonata",
+    "Forces": "ob vn bc",
+    "Key": "F major",
+    "Date": "1713–16?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1041",
+    "BC": "—",
+    "Title": "Violin Concerto",
+    "Forces": "vn str bc",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "arr. for hpd str bc as BWV 1058"
+  },
+  {
+    "BWV": "1042",
+    "BC": "—",
+    "Title": "Violin Concerto",
+    "Forces": "vn str bc",
+    "Key": "E major",
+    "Date": "1720?",
+    "Genre": "Orchestral",
+    "Notes": "arr. for hpd str bc as BWV 1054"
+  },
+  {
+    "BWV": "1043",
+    "BC": "—",
+    "Title": "Concerto for 2 Violins(\"Double Concerto\")",
+    "Forces": "2vn bc str",
+    "Key": "D minor",
+    "Date": "1718–20?",
+    "Genre": "Orchestral",
+    "Notes": "arr. for hpd str bc as BWV 1062"
+  },
+  {
+    "BWV": "1044",
+    "BC": "—",
+    "Title": "Concerto for Flute, Violin and Harpsichord(\"Triple Concerto\")",
+    "Forces": "fl hpd vn str bc",
+    "Key": "A minor",
+    "Date": "1738–40?",
+    "Genre": "Orchestral",
+    "Notes": "movts. based on BWV 894/1, 527/2, 894/3 respectively"
+  },
+  {
+    "BWV": "1045",
+    "BC": "A193",
+    "Title": "Sinfonia",
+    "Forces": "vn orch",
+    "Key": "D major",
+    "Date": "1743–46?",
+    "Genre": "Orchestral",
+    "Notes": "from a lost cantata; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1046",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.1",
+    "Forces": "orch",
+    "Key": "F major",
+    "Date": "1721",
+    "Genre": "Orchestral",
+    "Notes": "2nd version of BWV 1046"
+  },
+  {
+    "BWV": "1046a(1071)",
+    "BC": "—",
+    "Title": "Sinfonia",
+    "Forces": "orch",
+    "Key": "F major",
+    "Date": "1718",
+    "Genre": "Orchestral",
+    "Notes": "1st version of BWV 1046"
+  },
+  {
+    "BWV": "1047",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.2",
+    "Forces": "orch",
+    "Key": "F major",
+    "Date": "1718",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1048",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.3",
+    "Forces": "hpd str",
+    "Key": "G major",
+    "Date": "1718",
+    "Genre": "Orchestral",
+    "Notes": "1st movt. arr. for orch as Sinfonia of BWV 174"
+  },
+  {
+    "BWV": "1049",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.4",
+    "Forces": "orch",
+    "Key": "G major",
+    "Date": "1719–20",
+    "Genre": "Orchestral",
+    "Notes": "arr. for 2rec hpd str bc as BWV 1057"
+  },
+  {
+    "BWV": "1050",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.5",
+    "Forces": "orch",
+    "Key": "D major",
+    "Date": "1720–21",
+    "Genre": "Orchestral",
+    "Notes": "see also BWV 1050a"
+  },
+  {
+    "BWV": "1050a",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.5",
+    "Forces": "orch",
+    "Key": "D major",
+    "Date": "1719?",
+    "Genre": "Orchestral",
+    "Notes": "early version of BWV 1050"
+  },
+  {
+    "BWV": "1051",
+    "BC": "—",
+    "Title": "Brandenburg Concerto No.6",
+    "Forces": "hpd str",
+    "Key": "B♭major",
+    "Date": "1718",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1052",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.1",
+    "Forces": "hpd str bc",
+    "Key": "D minor",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost Violin Concerto (see BWV 1052R); partly re-used in BWV 146, BWV 188; see also BWV 1052a"
+  },
+  {
+    "BWV": "1052a",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.1",
+    "Forces": "hpd str bc",
+    "Key": "D minor",
+    "Date": "1734",
+    "Genre": "Orchestral",
+    "Notes": "earlier version of BWV 1052; possibly an arr. by C. P. E. Bach"
+  },
+  {
+    "BWV": "1052R",
+    "BC": "—",
+    "Title": "Violin Concerto",
+    "Forces": "vn str bc",
+    "Key": "D minor",
+    "Date": "1730–34?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 146, 188, 1052a and 1052"
+  },
+  {
+    "BWV": "1053",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.2",
+    "Forces": "hpd str bc",
+    "Key": "E major",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost Oboe Concerto (see BWV 1053R); partly re-used in BWV 49, BWV 169"
+  },
+  {
+    "BWV": "1053R",
+    "BC": "—",
+    "Title": "Oboe Concerto",
+    "Forces": "ob/oda str bc",
+    "Key": "F major",
+    "Date": "1730–38?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 49, 169 and 1053. Also has been reconstructed for Oboe d'amore."
+  },
+  {
+    "BWV": "1054",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.3",
+    "Forces": "hpd str bc",
+    "Key": "D major",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of BWV 1042"
+  },
+  {
+    "BWV": "1055",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.4",
+    "Forces": "hpd str bc",
+    "Key": "A major",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost concerto for oboe d'amore (see BWV 1055R)"
+  },
+  {
+    "BWV": "1055R",
+    "BC": "—",
+    "Title": "Oboe d'amore Concerto",
+    "Forces": "oda str bc",
+    "Key": "A major",
+    "Date": "1730–38?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 1055"
+  },
+  {
+    "BWV": "1056",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.5",
+    "Forces": "hpd str bc",
+    "Key": "F minor",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost violin concerto; partly re-used in BWV 156"
+  },
+  {
+    "BWV": "1056R",
+    "BC": "—",
+    "Title": "Violin Concerto",
+    "Forces": "vn str bc",
+    "Key": "G minor",
+    "Date": "1730–38?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 1056"
+  },
+  {
+    "BWV": "1057",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.6",
+    "Forces": "2rec hpd str bc",
+    "Key": "F major",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of BWV 1049"
+  },
+  {
+    "BWV": "1058",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.7",
+    "Forces": "hpd str bc",
+    "Key": "G minor",
+    "Date": "1738",
+    "Genre": "Orchestral",
+    "Notes": "arr. of BWV 1041"
+  },
+  {
+    "BWV": "1059",
+    "BC": "—",
+    "Title": "Harpsichord Concerto No.8",
+    "Forces": "hpd ob str bc",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost oboe concerto (see BWV 1059R); incomplete; partly rev. as BWV 35"
+  },
+  {
+    "BWV": "1059R",
+    "BC": "—",
+    "Title": "Oboe Concerto",
+    "Forces": "ob str bc",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 35, 156, and 1059"
+  },
+  {
+    "BWV": "1060",
+    "BC": "—",
+    "Title": "Concerto for 2 Harpsichords",
+    "Forces": "2hpd str bc",
+    "Key": "C minor",
+    "Date": "1730–45?",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost concerto for oboe and violin (see BWV 1060R)"
+  },
+  {
+    "BWV": "1060R",
+    "BC": "—",
+    "Title": "Concerto for Oboe and Violin",
+    "Forces": "ob vn str bc",
+    "Key": "C minor",
+    "Date": "1719?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 1060"
+  },
+  {
+    "BWV": "1061",
+    "BC": "—",
+    "Title": "Concerto for 2 Harpsichords",
+    "Forces": "2hpd str bc",
+    "Key": "C major",
+    "Date": "1733–34",
+    "Genre": "Orchestral",
+    "Notes": "2nd version of BWV 1061a"
+  },
+  {
+    "BWV": "1061a",
+    "BC": "—",
+    "Title": "Concerto for 2 Harpsichords",
+    "Forces": "2hpd",
+    "Key": "C major",
+    "Date": "1732–33",
+    "Genre": "Orchestral",
+    "Notes": "1st version of BWV 1061"
+  },
+  {
+    "BWV": "1062",
+    "BC": "—",
+    "Title": "Concerto for 2 Harpsichords",
+    "Forces": "2hpd str bc",
+    "Key": "C minor",
+    "Date": "1736",
+    "Genre": "Orchestral",
+    "Notes": "arr. of BWV 1043"
+  },
+  {
+    "BWV": "1063",
+    "BC": "—",
+    "Title": "Concerto for 3 Harpsichords",
+    "Forces": "3hpd str bc",
+    "Key": "D minor",
+    "Date": "1735–45?",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1064",
+    "BC": "—",
+    "Title": "Concerto for 3 Harpsichords",
+    "Forces": "3hpd str bc",
+    "Key": "C major",
+    "Date": "1735–45?",
+    "Genre": "Orchestral",
+    "Notes": "arr. of a lost concerto for 3vn (see BWV 1064R)"
+  },
+  {
+    "BWV": "1064R",
+    "BC": "—",
+    "Title": "Concerto for 3 Violins",
+    "Forces": "3vn str bc",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "lost, but reconstructed from BWV 1064"
+  },
+  {
+    "BWV": "1065",
+    "BC": "—",
+    "Title": "Concerto for 4 Harpsichords",
+    "Forces": "4hpd str bc",
+    "Key": "A minor",
+    "Date": "1730?",
+    "Genre": "Orchestral",
+    "Notes": "arr. of theConcerto for 4 Violins and Cello in B minor, RV 580, byAntonio Vivaldi"
+  },
+  {
+    "BWV": "1066",
+    "BC": "—",
+    "Title": "Orchestral Suite No.1(Overture)",
+    "Forces": "orch",
+    "Key": "C major",
+    "Date": "1718?",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1067",
+    "BC": "—",
+    "Title": "Orchestral Suite No.2(Overture)",
+    "Forces": "orch",
+    "Key": "B minor",
+    "Date": "1738–39",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1068",
+    "BC": "—",
+    "Title": "Orchestral Suite No.3(Overture)",
+    "Forces": "orch",
+    "Key": "D major",
+    "Date": "1731",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1069",
+    "BC": "—",
+    "Title": "Orchestral Suite No.4(Overture)",
+    "Forces": "orch",
+    "Key": "D major",
+    "Date": "1725",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "1070",
+    "BC": "—",
+    "Title": "Overture(\"Orchestral Suite No.5\")",
+    "Forces": "orch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1071",
+    "BC": "—",
+    "Title": "Sinfonia",
+    "Forces": "orch",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "—",
+    "Notes": "see BWV 1046a"
+  },
+  {
+    "BWV": "1072",
+    "BC": "—",
+    "Title": "Canon(\"Canon trias harmonica\")",
+    "Forces": "8vv",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1073",
+    "BC": "—",
+    "Title": "Canon(\"Canon a 4 perpetuus\")",
+    "Forces": "4open",
+    "Key": "A minor",
+    "Date": "1713",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1074",
+    "BC": "—",
+    "Title": "Canon(\"Canon a 4\")",
+    "Forces": "4open",
+    "Key": "A minor",
+    "Date": "1727",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1075",
+    "BC": "—",
+    "Title": "Canon(\"Canon a 2 perpetuus\")",
+    "Forces": "2open",
+    "Key": "D major",
+    "Date": "1734",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1076",
+    "BC": "—",
+    "Title": "Canon(\"Canon triplex a 6\")",
+    "Forces": "4open",
+    "Key": "G major",
+    "Date": "1746",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1077",
+    "BC": "—",
+    "Title": "Canon(\"Canone doppio sopr' il soggetto\")",
+    "Forces": "3open",
+    "Key": "G major",
+    "Date": "1747",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1078",
+    "BC": "—",
+    "Title": "Canon(\"Canon super fa miá 7 post tempus musicum\")",
+    "Forces": "7open",
+    "Key": "F major",
+    "Date": "1749",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1079",
+    "BC": "—",
+    "Title": "Musikalisches Opfer(\"Musical Offering\")",
+    "Forces": "fl hpd 2vn",
+    "Key": "",
+    "Date": "1747",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1080",
+    "BC": "—",
+    "Title": "Die Kunst der Fuge(\"The Art of the Fugue\")",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1748–49",
+    "Genre": "Keyboard",
+    "Notes": "incomplete"
+  },
+  {
+    "BWV": "1081",
+    "BC": "—",
+    "Title": "Credo in unum Deum",
+    "Forces": "ch bc",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "chorale for aMissa brevisbyGiovanni Battista Bassani"
+  },
+  {
+    "BWV": "1082",
+    "BC": "E15",
+    "Title": "Suscepit Israel puerum suum",
+    "Forces": "ch str bc",
+    "Key": "E minor",
+    "Date": "1740–42",
+    "Genre": "Vocal",
+    "Notes": "arr. of the 3rd movt. of the Magnificat in C major byAntonio Caldara"
+  },
+  {
+    "BWV": "1083",
+    "BC": "—",
+    "Title": "Tilge, Höchster, meine Sünden(Psalm 51)",
+    "Forces": "2vv str bc",
+    "Key": "",
+    "Date": "1745–47",
+    "Genre": "Vocal",
+    "Notes": "adaptation of theStabat MaterbyGiovanni Battista Pergolesi"
+  },
+  {
+    "BWV": "1084",
+    "BC": "D05",
+    "Title": "O hilf, Christe, Gottes Sohn",
+    "Forces": "ch vn 2va bc",
+    "Key": "D minor",
+    "Date": "1726",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "1085",
+    "BC": "K110",
+    "Title": "O Lamm Gottes unschuldig(IV)",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1715–18?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1086",
+    "BC": "—",
+    "Title": "Canon(\"Concordia discors\")",
+    "Forces": "2open",
+    "Key": "D major",
+    "Date": "1750?",
+    "Genre": "Chamber",
+    "Notes": ""
+  },
+  {
+    "BWV": "1087",
+    "BC": "—",
+    "Title": "Canons(14)",
+    "Forces": "6open",
+    "Key": "G major",
+    "Date": "1747–48",
+    "Genre": "Chamber",
+    "Notes": "based on the theme of BWV 988"
+  },
+  {
+    "BWV": "1088",
+    "BC": "D10",
+    "Title": "So heb ich denn mein Auge sehnlich auf",
+    "Forces": "v 2bn/2vc bc",
+    "Key": "G minor/ E♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "intended for thePassions-PasticciobyKarl Heinrich Graun; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1089",
+    "BC": "F109.1",
+    "Title": "Da Jesus an dem Kreuze stund",
+    "Forces": "ch",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "1089z1090–1120",
+    "BC": "—",
+    "Title": "Chorale Preludes(\"Neumeister Chorales\") (31):",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1090",
+    "BC": "K161",
+    "Title": "Wir Christenleut'(II)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1091",
+    "BC": "K162",
+    "Title": "Das alte Jahr vergangen ist(II)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1092",
+    "BC": "K163",
+    "Title": "Herr Gott, nun schleuss den Himmel auf(II)",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1093",
+    "BC": "K164",
+    "Title": "Herzliebster Jesu, was hast du verbrochen(I)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1094",
+    "BC": "K165",
+    "Title": "O Jesu, wie ist dein Gestalt",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1095",
+    "BC": "K166",
+    "Title": "O Lamm Gottes unschuldig(V)",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1096",
+    "BC": "K167",
+    "Title": "Christ, der du bist Tag und Licht",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": "also attributed toJohann Pachelbel"
+  },
+  {
+    "BWV": "1097",
+    "BC": "K168",
+    "Title": "Ehre sei dir Christe, der du leidest Not",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1098",
+    "BC": "K169",
+    "Title": "Wir glauben all an einen Gott(III)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1099",
+    "BC": "K170",
+    "Title": "Aus tiefer Not schrei ich zu dir(III)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1100",
+    "BC": "K171",
+    "Title": "Allein zu dir, Herr Jesu Christ",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1101",
+    "BC": "K174",
+    "Title": "Durch Adams Fall ist ganz verderbt(III)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1102",
+    "BC": "K175",
+    "Title": "Du Friedefürst, Herr Jesu Christ",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1103",
+    "BC": "K176",
+    "Title": "Erhalt uns Herr, bei deinem Wort(I)",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1104",
+    "BC": "K177",
+    "Title": "Wenn dich Unglück tut greifen an",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1105",
+    "BC": "K178",
+    "Title": "Jesu, meine Freude(III)",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1106",
+    "BC": "K179",
+    "Title": "Gott ist mein Heil, mein Hilf und Trost",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1107",
+    "BC": "K180",
+    "Title": "Jesu, meines Lebens Leben(I)",
+    "Forces": "org",
+    "Key": "D major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1108",
+    "BC": "K181",
+    "Title": "Als Jesus Christus in der Nacht",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1109",
+    "BC": "K182",
+    "Title": "Ach Gott, tu dich erbarmen",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1110",
+    "BC": "K183",
+    "Title": "O Herre Gott, dein göttlich Wort(II)",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1111",
+    "BC": "K184",
+    "Title": "Nun lasst uns den Leib begraben",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1112",
+    "BC": "K185",
+    "Title": "Christus, der ist mein Leben",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1113",
+    "BC": "K186",
+    "Title": "Ich hab mein Sach Gott heimgestellt(IV)",
+    "Forces": "org",
+    "Key": "B minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1114",
+    "BC": "K187",
+    "Title": "Herr Jesu Christ, du höchstes Gut",
+    "Forces": "org",
+    "Key": "F minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1115",
+    "BC": "K188",
+    "Title": "Herzlich lieb hab ich dich, o Herr",
+    "Forces": "org",
+    "Key": "C major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1116",
+    "BC": "K189",
+    "Title": "Was Gott tut, das ist wohlgetan(I)",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1117",
+    "BC": "K190",
+    "Title": "Alle Menschen müssen sterben(II)",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1118",
+    "BC": "K192",
+    "Title": "Werde munter, mein Gemüte",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1119",
+    "BC": "K193",
+    "Title": "Wie nach einer Wasserquelle",
+    "Forces": "org",
+    "Key": "D minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1120",
+    "BC": "K194",
+    "Title": "Christ, der du bist der helle Tag",
+    "Forces": "org",
+    "Key": "E minor",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1121",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1706–10",
+    "Genre": "Keyboard",
+    "Notes": "formerly BWV Anh.205"
+  },
+  {
+    "BWV": "1121z1122–1126",
+    "BC": "—",
+    "Title": "Chorale Preludes(5):",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1703–07?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1122",
+    "BC": "—",
+    "Title": "Denket doch, ihr Menschenkinder",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1123",
+    "BC": "—",
+    "Title": "Wo Gott zum Haus nicht gibt sein' Gunst(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1124",
+    "BC": "—",
+    "Title": "Ich ruf zu dir, Herr Jesu Christ",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1125",
+    "BC": "—",
+    "Title": "O Gott, du frommer Gott(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1126",
+    "BC": "—",
+    "Title": "Lobet Gott, unseren Herren",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": ""
+  },
+  {
+    "BWV": "1127",
+    "BC": "—",
+    "Title": "Alles mit Gott, nichts ohn' ihn",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1713",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "1128",
+    "BC": "—",
+    "Title": "Wo Gott der Herr nicht bei uns hält",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "formerly BWV Anh.71"
+  },
+  {
+    "BWV": "1129",
+    "BC": "—",
+    "Title": "Theoretische Aufzeichnungen zum fünfstimmigen Satz",
+    "Forces": "text",
+    "Key": "",
+    "Date": "",
+    "Genre": "Text",
+    "Notes": "Regula Joh. Seb. Bachii"
+  },
+  {
+    "BWV": "1130",
+    "BC": "—",
+    "Title": "Theoretische Aufzeichnungen zum Kontrapunkt",
+    "Forces": "text",
+    "Key": "",
+    "Date": "1742-43",
+    "Genre": "Text",
+    "Notes": "Canones aliquot per Josephum Zarlinum"
+  },
+  {
+    "BWV": "1131",
+    "BC": "—",
+    "Title": "Regeln zum Gebrauch von Synkopen im doppelten Kontrapunkt",
+    "Forces": "text",
+    "Key": "",
+    "Date": "1743-46",
+    "Genre": "Text",
+    "Notes": ""
+  },
+  {
+    "BWV": "1132",
+    "BC": "—",
+    "Title": "Kontrapunktstudien",
+    "Forces": "—",
+    "Key": "",
+    "Date": "1743-46",
+    "Genre": "—",
+    "Notes": ""
+  },
+  {
+    "BWV": "1133",
+    "BC": "—",
+    "Title": "Einige höchst nöthige Regeln vom General Basso",
+    "Forces": "text",
+    "Key": "",
+    "Date": "1740-45",
+    "Genre": "Text",
+    "Notes": "Basso continuo rules (Generalbassregeln I)"
+  },
+  {
+    "BWV": "1134",
+    "BC": "—",
+    "Title": "Vorschriften und Grundsätze zum vierstimmigen Spielen des General-Bass oder Accompagnement",
+    "Forces": "text",
+    "Key": "",
+    "Date": "1738?",
+    "Genre": "Text",
+    "Notes": "Basso continuo rules (Generalbassregeln II)"
+  },
+  {
+    "BWV": "1135",
+    "BC": "—",
+    "Title": "Siehe, eine Jungfrau ist schwanger",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "formerly BWV Anh.199.Cantata for the Feast of the Annunciation; lost"
+  },
+  {
+    "BWV": "1136",
+    "BC": "—",
+    "Title": "Liebster Gott, vergisst du mich",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1714-17",
+    "Genre": "Vocal",
+    "Notes": "formerly BWV Anh.209."
+  },
+  {
+    "BWV": "1137",
+    "BC": "B02",
+    "Title": "Zweite Kantate zur Mühlhäuser Ratswahl",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1709",
+    "Genre": "Vocal",
+    "Notes": "formerly BWV Anh.192. 2nd Cantata for the inauguration of Mühlhausen town council; lost"
+  },
+  {
+    "BWV": "1138",
+    "BC": "—",
+    "Title": "Dritte Kantate zur Mühlhäuser Ratswahl",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1710",
+    "Genre": "Vocal",
+    "Notes": "3rd Cantata for the inauguration of Mühlhausen town council; lost"
+  },
+  {
+    "BWV": "1139",
+    "BC": "B04a",
+    "Title": "Wünschet Jerusalem Glück",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "formerly BWV Anh.192. Cantata for the inauguration of Leipzig town council; 1st version of BWV 1139a; music lost"
+  },
+  {
+    "BWV": "1139a",
+    "BC": "B29",
+    "Title": "Wünschet Jerusalem Glück",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.4a. Cantata for the 3rd day of the 200th anniversary of the Augsburg Confession; 2nd version of BWV 1139; music lost"
+  },
+  {
+    "BWV": "1140",
+    "BC": "B07",
+    "Title": "Gott, gib dein Gerichte dem Könige",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.3. Cantata for the inauguration of Leipzig town council; music lost"
+  },
+  {
+    "BWV": "1141",
+    "BC": "B09",
+    "Title": "Herrscher des Himmels, König der Ehren",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1740",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.193. cantata for the inauguration of Leipzig town council; last chorus based on BWV 208, otherwise lost"
+  },
+  {
+    "BWV": "1142",
+    "BC": "B19",
+    "Title": "Was ist, das wir Leben nennen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1716",
+    "Genre": "Vocal",
+    "Notes": "cantata for the memorial service for Prince Johann Ernst of Saxe-Weimar, otherwise lost"
+  },
+  {
+    "BWV": "1143",
+    "BC": "B22",
+    "Title": "Klagt, Kinder, klagt es aller Welt",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "see BWV 244a. Partly based on BWV 198, BWV 247, BWV 244b; lost"
+  },
+  {
+    "BWV": "1144",
+    "BC": "B12",
+    "Title": "Sein Segen fliesst daher wie ein Strom",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.14. Wedding cantata for Christoph Friedrich Lösner and Johanna Elisabetha Scherling; music lost"
+  },
+  {
+    "BWV": "1145",
+    "BC": "—",
+    "Title": "Der Herr ist freundlich dem, der auf ihn harret",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.211. Cantata for the wedding of the lawyer and university professor Johann Friedrich Höckner with Jacobina Agnetha Bartholomäus, otherwise music lost"
+  },
+  {
+    "BWV": "1146",
+    "BC": "—",
+    "Title": "Vergnügende Flammen, verdoppelt die Macht",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.212. Cantata for the wedding of the merchant Christoph Georg Winckler with Caroline Wilhelmine Jöcher, otherwise music lost"
+  },
+  {
+    "BWV": "1147",
+    "BC": "B30",
+    "Title": "Lobet der Herrn, alle seine Heerscharen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1718",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.5. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
+  },
+  {
+    "BWV": "1148",
+    "BC": "B32",
+    "Title": "Siehe, der Hüter Israel",
+    "Forces": "4vv orch",
+    "Key": "",
+    "Date": "1724?",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.15. Cantata for a degree ceremony at Leipzig University; fragment only"
+  },
+  {
+    "BWV": "1149",
+    "BC": "D10/3",
+    "Title": "Der Gerechte kömmt um",
+    "Forces": "5vv orch",
+    "Key": "",
+    "Date": "",
+    "Genre": "Vocal",
+    "Notes": "arrangement of the motet \"Tristis est anima mea\" probably byJohann Kuhnau"
+  },
+  {
+    "BWV": "1150",
+    "BC": "—",
+    "Title": "Ihr wallenden Wolken",
+    "Forces": "bass orch",
+    "Key": "",
+    "Date": "1721-22",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.197. Cantata as a tribute music in honor of the princely house of Anhalt-Köthen or was for New Year's Day; lost"
+  },
+  {
+    "BWV": "1151",
+    "BC": "G06",
+    "Title": "Dich loben die lieblichen Strahlen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1719",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.6. Cantata for New Year's Day; music lost"
+  },
+  {
+    "BWV": "1152",
+    "BC": "G10",
+    "Title": "Cantata (Glückwunschkantate zum Neujahrstag)",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1722",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.8. Cantata for New Year's Day; lost; possibly the same as BWV 184a"
+  },
+  {
+    "BWV": "1153",
+    "BC": "G07",
+    "Title": "Heut ist gewiss ein guter Tag",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.7. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
+  },
+  {
+    "BWV": "1154",
+    "BC": "—",
+    "Title": "O vergnügte Stunden",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1722",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.194. Cantata for the birthday of Johann August of Anhalt-Zerbst; lost"
+  },
+  {
+    "BWV": "1155",
+    "BC": "G33",
+    "Title": "Lateinische Ode",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.20. Cantata (ode) for the birthday of Duke Friedrich II of Saxe-Gotha; music lost"
+  },
+  {
+    "BWV": "1156",
+    "BC": "G14",
+    "Title": "Entfernet euch, ihr heitern Sterne",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.9. Cantata for birthday of King August III; music lost"
+  },
+  {
+    "BWV": "1157",
+    "BC": "G16",
+    "Title": "Es lebe der König, der Vater im Lande",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1732",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.11. Cantata for the nameday of King August II of Poland; music lost"
+  },
+  {
+    "BWV": "1158",
+    "BC": "G17",
+    "Title": "Frohes Volk, vergnügte Sachsen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1733",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.12. Cantata for the nameday of King August III of Poland; based on BWV Anh.18; music lost"
+  },
+  {
+    "BWV": "1159",
+    "BC": "G25",
+    "Title": "Glückwunschkantate / Serenade",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1739",
+    "Genre": "Vocal",
+    "Notes": "cantata for the birthday of King August III of Poland; libretto and music lost"
+  },
+  {
+    "BWV": "1160",
+    "BC": "G30",
+    "Title": "So kämpfet nur, ihr muntern Töne",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.10. Cantata for the birthday of Joachim Friedrich Reichsgraf von Flemming; music lost"
+  },
+  {
+    "BWV": "1161",
+    "BC": "G24",
+    "Title": "Willkommen! Ihr herrschenden Götter",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1738",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.13. Cantata for the wedding of Prince Carl IV and Princess Maria Amalia; music lost"
+  },
+  {
+    "BWV": "1162",
+    "BC": "G39",
+    "Title": "Froher Tag, verlangte Stunden",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1732",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.18. Cantata for occasion of the rededication of the rebuilt St. Thomas School; music lost; rev. as BWV Anh.12"
+  },
+  {
+    "BWV": "1163",
+    "BC": "G42",
+    "Title": "Auf, süß entzückende Gewalt",
+    "Forces": "4vv ch orch?",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "formally BWV Anh.196. Cantata on the occasion of the wedding of Peter Hohman the Younger; music lost"
+  },
+  {
+    "BWV": "1164",
+    "BC": "—",
+    "Title": "Aria",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1731-32",
+    "Genre": "Vocal",
+    "Notes": "music lost"
+  },
+  {
+    "BWV": "1165",
+    "BC": "C9",
+    "Title": "Ich lasse dich nicht, du segnest mich denn",
+    "Forces": "2ch",
+    "Key": "",
+    "Date": "1713?",
+    "Genre": "Vocal",
+    "Notes": "formerly BWV Anh.159. Attributed toJohann Christoph Bach"
+  },
+  {
+    "BWV": "1166",
+    "BC": "—",
+    "Title": "Markus-Passion Pasticcio",
+    "Forces": "4vv ch orch",
+    "Key": "",
+    "Date": "1713?",
+    "Genre": "Vocal",
+    "Notes": ""
+  },
+  {
+    "BWV": "1167",
+    "BC": "D10",
+    "Title": "Beiträge zur Passionsmusik \"Wer ist der, so von Edom kömmt (Pasticcio-Bearbeitung) von Carl Heinrich Graun's „Kleiner Passion“ (GraunWV B:VII:4) mit Sätzen von Johann Sebastian Bach und Georg Philipp Telemann",
+    "Forces": "5vv orch",
+    "Key": "",
+    "Date": "1735-50",
+    "Genre": "Vocal",
+    "Notes": "is based onKarl Heinrich Graun's Passion cantata \"Ein Lämmlein geht und tragen die Schuld\" (so-called \"Kleine Passion\" (GraunWV B:VII:4), Braunschweig before 1735) withGeorg Philipp Telemann's opening chorus, \"Wer ist der, so von Edom kömmt\" TVWV 1:1585 (from the Palmarum cantata of the French vintage), and the following chorale movement for \"Christus, der uns selig macht\" (from D to E transposed final chorale of the same cantata); the following movements (3rd–18th) are all by Graun."
+  },
+  {
+    "BWV": "1168",
+    "BC": "—",
+    "Title": "Concerto",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "formally BWV Anh.213. Arrangement of a concerto byGeorg Philipp Telemann"
+  },
+  {
+    "BWV": "1169",
+    "BC": "K054",
+    "Title": "O Traurigkeit, o Herzeleid",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": "formally BWV Anh.200. Incomplete"
+  },
+  {
+    "BWV": "1170",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1714–17",
+    "Genre": "Keyboard",
+    "Notes": "formally BWV Anh.55. Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1171",
+    "BC": "—",
+    "Title": "Auf meinen lieben Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1172",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1173",
+    "BC": "—",
+    "Title": "Ich ruf zu dir, Herr Jesu Christ",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1174",
+    "BC": "—",
+    "Title": "Komm, heiliger Geist, erfüll die Herzen",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1175",
+    "BC": "—",
+    "Title": "Es ist das Heil uns kommen her",
+    "Forces": "org",
+    "Key": "",
+    "Date": "",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1176",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": "formally BWV Anh.77. Bach's authorship uncertain"
+  },
+  {
+    "BWV": "1177",
+    "BC": "—",
+    "Title": "March",
+    "Forces": "orch",
+    "Key": "D major",
+    "Date": "1726",
+    "Genre": "Orchestral",
+    "Notes": ""
+  },
+  {
+    "BWV": "Anh.001",
+    "BC": "—",
+    "Title": "Gesegnet ist die Zuversicht",
+    "Forces": "vv 2fl str bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:617)"
+  },
+  {
+    "BWV": "Anh.002",
+    "BC": "A147",
+    "Title": "Cantata",
+    "Forces": "4vv ch str bc",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "cantata for the 19th Sunday after Trinity; fragment only"
+  },
+  {
+    "BWV": "Anh.003",
+    "BC": "B07",
+    "Title": "Gott, gib dein Gerichte dem Könige",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1140. Cantata for the inauguration of Leipzig town council; music lost"
+  },
+  {
+    "BWV": "Anh.004",
+    "BC": "B04a",
+    "Title": "Wünschet Jerusalem Glück",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1139. Cantata for the inauguration of Leipzig town council; 1st version of BWV Anh.4a; music lost"
+  },
+  {
+    "BWV": "Anh.004a",
+    "BC": "B29",
+    "Title": "Wünschet Jerusalem Glück",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1730",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1139a. Cantata for the 3rd day of the 200th anniversary of the Augsburg Confession; 2nd version of BWV Anh.4; music lost"
+  },
+  {
+    "BWV": "Anh.005",
+    "BC": "B30",
+    "Title": "Lobet der Herrn, alle seine Heerscharen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1718",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1147. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
+  },
+  {
+    "BWV": "Anh.006",
+    "BC": "G06",
+    "Title": "Dich loben die lieblichen Strahlen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1719",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1151. Cantata for New Year's Day; music lost"
+  },
+  {
+    "BWV": "Anh.007",
+    "BC": "G07",
+    "Title": "Heut ist gewiss ein guter Tag",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1720",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1153. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
+  },
+  {
+    "BWV": "Anh.008",
+    "BC": "G10",
+    "Title": "Cantata (Glückwunschkantate zum Neujahrstag)",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1722",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1152. Cantata for New Year's Day; lost; possibly the same as BWV 184a"
+  },
+  {
+    "BWV": "Anh.009",
+    "BC": "G14",
+    "Title": "Entfernet euch, ihr heitern Sterne",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1727",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1156. Cantata for birthday of King August III; music lost"
+  },
+  {
+    "BWV": "Anh.010",
+    "BC": "G30",
+    "Title": "So kämpfet nur, ihr muntern Töne",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1731",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1160. Cantata for the birthday of Joachim Friedrich Reichsgraf von Flemming; music lost"
+  },
+  {
+    "BWV": "Anh.011",
+    "BC": "G16",
+    "Title": "Es lebe der König, der Vater im Lande",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1732",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1157. Cantata for the nameday of King August II of Poland; music lost"
+  },
+  {
+    "BWV": "Anh.012",
+    "BC": "G17",
+    "Title": "Frohes Volk, vergnügte Sachsen",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1733",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1158. Cantata for the nameday of King August III of Poland; based on BWV Anh.18; music lost"
+  },
+  {
+    "BWV": "Anh.013",
+    "BC": "G24",
+    "Title": "Willkommen! Ihr herrschenden Götter",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1738",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1161. Cantata for the wedding of Prince Carl IV and Princess Maria Amalia; music lost"
+  },
+  {
+    "BWV": "Anh.014",
+    "BC": "B12",
+    "Title": "Sein Segen fliesst daher wie ein Strom",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1144. Wedding cantata for Christoph Friedrich Lösner and Johanna Elisabetha Scherling; music lost"
+  },
+  {
+    "BWV": "Anh.015",
+    "BC": "B32",
+    "Title": "Siehe, der Hüter Israel",
+    "Forces": "4vv orch",
+    "Key": "",
+    "Date": "1724?",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1148. Cantata for a degree ceremony at Leipzig University; fragment only"
+  },
+  {
+    "BWV": "Anh.016",
+    "BC": "—",
+    "Title": "Schließt die Gruft! Ihr Trauerglocken",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1735",
+    "Genre": "Vocal",
+    "Notes": "funeral cantata; music lost"
+  },
+  {
+    "BWV": "Anh.017",
+    "BC": "—",
+    "Title": "Mein Gott, nimm die gerechte Seele",
+    "Forces": "4vv orch",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "funeral cantata; fragments only"
+  },
+  {
+    "BWV": "Anh.018",
+    "BC": "G39",
+    "Title": "Froher Tag, verlangte Stunden",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1732",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1162. Cantata for occasion of the rededication of the rebuilt St. Thomas School; music lost; rev. as BWV Anh.12"
+  },
+  {
+    "BWV": "Anh.019",
+    "BC": "G40",
+    "Title": "Thomana saß annoch betrübt",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "cantata for the Thomasschule in Leipzig; music lost"
+  },
+  {
+    "BWV": "Anh.020",
+    "BC": "G33",
+    "Title": "Lateinische Ode",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1155. Cantata (ode) for the birthday of Duke Friedrich II of Saxe-Gotha; music lost"
+  },
+  {
+    "BWV": "Anh.021",
+    "BC": "—",
+    "Title": "Magnificat(\"Kleine Magnificat\")",
+    "Forces": "v fl str bc",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byMelchior Hoffmann"
+  },
+  {
+    "BWV": "Anh.022",
+    "BC": "—",
+    "Title": "Concerto for Oboe and Violin",
+    "Forces": "ob vb orch",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "lost, only the theme remains"
+  },
+  {
+    "BWV": "Anh.023",
+    "BC": "—",
+    "Title": "Concerto",
+    "Forces": "str bc",
+    "Key": "E minor",
+    "Date": "—",
+    "Genre": "Orchestral",
+    "Notes": "bc part only; spurious; composed byTomaso Albinoni"
+  },
+  {
+    "BWV": "Anh.024",
+    "BC": "—",
+    "Title": "Mass",
+    "Forces": "ch str bc",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Christoph Pez"
+  },
+  {
+    "BWV": "Anh.025",
+    "BC": "—",
+    "Title": "Mass",
+    "Forces": "ch orch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.026",
+    "BC": "—",
+    "Title": "Mass",
+    "Forces": "ch orch",
+    "Key": "C minor",
+    "Date": "1727–32",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byFrancesco Durante, butChriste eleisonadapted by Bach as BWV 242"
+  },
+  {
+    "BWV": "Anh.027",
+    "BC": "—",
+    "Title": "Sanctus",
+    "Forces": "ch orch",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Ludwig Krebs)"
+  },
+  {
+    "BWV": "Anh.028",
+    "BC": "—",
+    "Title": "Sanctus",
+    "Forces": "ch orch",
+    "Key": "B♭major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.029",
+    "BC": "—",
+    "Title": "Mass",
+    "Forces": "?",
+    "Key": "C minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "bass part only; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.030",
+    "BC": "—",
+    "Title": "Magnificat",
+    "Forces": "2ch orch",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain; possibly composed byAntonio Lotti"
+  },
+  {
+    "BWV": "Anh.031",
+    "BC": "—",
+    "Title": "Herr Gott, dich loben alle wir",
+    "Forces": "ch 2tpt",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.031z32–39",
+    "BC": "—",
+    "Title": "Geistliche Oden und ein Gedicht(7):",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.032",
+    "BC": "—",
+    "Title": "Getrost mein Geist",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.033",
+    "BC": "—",
+    "Title": "Mein Jesus, spare nicht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.034",
+    "BC": "—",
+    "Title": "Kann ich mit einem Tone",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.035",
+    "BC": "—",
+    "Title": "Meine Seele lass die Flügel",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.036",
+    "BC": "—",
+    "Title": "Ich stimm'; itzund ein Straff-Lied an",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.037",
+    "BC": "—",
+    "Title": "Der schwarze Flügel trüber Nacht",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.038",
+    "BC": "—",
+    "Title": "Das Finsterniß tritt ein",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.039",
+    "BC": "—",
+    "Title": "Ach was wollt ihr trüben Sinnen",
+    "Forces": "v bc",
+    "Key": "",
+    "Date": "1704?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.040",
+    "BC": "—",
+    "Title": "Ich bin nun wie ich bin",
+    "Forces": "kbd (or voice, keyboard)",
+    "Key": "",
+    "Date": "1734?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.041",
+    "BC": "—",
+    "Title": "Dir zu Liebe, wertes Herze",
+    "Forces": "kbd (or voice, keyboard)",
+    "Key": "",
+    "Date": "1734?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.042",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.043",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "B minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.233, H.776)"
+  },
+  {
+    "BWV": "Anh.044",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Peter KellnerorJohann Christoph Kellner"
+  },
+  {
+    "BWV": "Anh.045",
+    "BC": "—",
+    "Title": "Fugue(on \"B-A-C-H\")",
+    "Forces": "org",
+    "Key": "B♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJustin Heinrich Knecht"
+  },
+  {
+    "BWV": "Anh.046",
+    "BC": "—",
+    "Title": "Trio",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Tobias Krebs"
+  },
+  {
+    "BWV": "Anh.047",
+    "BC": "—",
+    "Title": "Herzlich tut mich verlangen",
+    "Forces": "org",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Peter Kellner"
+  },
+  {
+    "BWV": "Anh.048",
+    "BC": "—",
+    "Title": "Allein Gott in der Höh sei Ehr",
+    "Forces": "org",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.049",
+    "BC": "—",
+    "Title": "Ein feste Burg ist unser Gott",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byJohann Gottfried Walther"
+  },
+  {
+    "BWV": "Anh.050",
+    "BC": "—",
+    "Title": "Erhalt uns, Herr, bei deinem Wort(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.051",
+    "BC": "—",
+    "Title": "Erstanden ist der heil'ge Christ(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.052",
+    "BC": "—",
+    "Title": "Freu dich sehr, o meine Seele",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.053",
+    "BC": "—",
+    "Title": "Schlage doch, gewünschte Stunde",
+    "Forces": "v bells str bc",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain; possibly composed byMelchior Hoffmann"
+  },
+  {
+    "BWV": "Anh.054",
+    "BC": "—",
+    "Title": "Helft mir Gott's Güte preisen(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.055",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1714–17",
+    "Genre": "Keyboard",
+    "Notes": "see BWV 1170. Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.056",
+    "BC": "—",
+    "Title": "Herr Jesu Christ, dich zu uns wend",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Philipp Telemann"
+  },
+  {
+    "BWV": "Anh.057",
+    "BC": "—",
+    "Title": "Jesu Leiden, Pein und Tod",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed by Johann Caspar Vogler"
+  },
+  {
+    "BWV": "Anh.058",
+    "BC": "—",
+    "Title": "Jesu, meine Freude(IV)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.059",
+    "BC": "—",
+    "Title": "Jesu, meine Freude(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.060",
+    "BC": "—",
+    "Title": "Nun lob' meine Seele",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Gottfried Walther"
+  },
+  {
+    "BWV": "Anh.061",
+    "BC": "—",
+    "Title": "O Mensch bewein dein' Sünde groß",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Pachelbel"
+  },
+  {
+    "BWV": "Anh.062a",
+    "BC": "—",
+    "Title": "Sei Lob und Ehr mit hohem Preis(I)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.062b",
+    "BC": "—",
+    "Title": "Sei Lob und Ehr mit hohem Preis(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.063",
+    "BC": "—",
+    "Title": "Vom Himmel hoch, da komm ich her(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.064",
+    "BC": "—",
+    "Title": "Vom Himmel hoch, da komm ich her(VII)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.065",
+    "BC": "—",
+    "Title": "Vom Himmel hoch, da komm ich her(VIII)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.066",
+    "BC": "—",
+    "Title": "Wachet auf, ruft uns die Stimme",
+    "Forces": "tpt org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.067",
+    "BC": "—",
+    "Title": "Was Gott tut, das ist wohlgetan(II)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.068",
+    "BC": "—",
+    "Title": "Wer nur den lieben Gott lässt walten(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.069",
+    "BC": "—",
+    "Title": "Wir glauben all an einen Gott(V)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.070",
+    "BC": "—",
+    "Title": "Wir glauben all an einen Gott(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.071",
+    "BC": "—",
+    "Title": "Wo Gott der Herr nicht bei uns hält",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "see BWV 1128"
+  },
+  {
+    "BWV": "Anh.072",
+    "BC": "—",
+    "Title": "Canon",
+    "Forces": "org",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.073",
+    "BC": "—",
+    "Title": "Ich ruf zu dir, Herr Jesu Christ(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "Anh.074",
+    "BC": "—",
+    "Title": "Schmücke dich, o liebe Seele(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGottfried August Homilius; see also BWV 759"
+  },
+  {
+    "BWV": "Anh.075",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn(III)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.076",
+    "BC": "—",
+    "Title": "Jesu, meine Freude(VI)",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.077",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "1718?",
+    "Genre": "Keyboard",
+    "Notes": "see BWV 1176. Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.078",
+    "BC": "—",
+    "Title": "Wenn wir in höchsten Nöten sein",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.079",
+    "BC": "—",
+    "Title": "Befiehl du deine Wege",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.080",
+    "BC": "—",
+    "Title": "Suite",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.081",
+    "BC": "—",
+    "Title": "Gigue",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "incomplete; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.082",
+    "BC": "—",
+    "Title": "Chaconne",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Bernhard Bach"
+  },
+  {
+    "BWV": "Anh.083",
+    "BC": "—",
+    "Title": "Chaconne",
+    "Forces": "kbd",
+    "Key": "A major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Bernhard Bach"
+  },
+  {
+    "BWV": "Anh.084",
+    "BC": "—",
+    "Title": "Chaconne",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Bernhard Bach"
+  },
+  {
+    "BWV": "Anh.085",
+    "BC": "—",
+    "Title": "Toccata and Fugue",
+    "Forces": "kbd",
+    "Key": "F minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.086",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.087",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.088",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Christoph Kellner"
+  },
+  {
+    "BWV": "Anh.089",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.090",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Philipp Kirnberger; formerly attributed toCarl Philipp Emanuel Bachas H.388"
+  },
+  {
+    "BWV": "Anh.091",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.092",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.093",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.094",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Philipp Kirnberger"
+  },
+  {
+    "BWV": "Anh.095",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.096",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.097",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "F♯major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "Anh.098",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
+  },
+  {
+    "BWV": "Anh.099",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
+  },
+  {
+    "BWV": "Anh.100",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
+  },
+  {
+    "BWV": "Anh.101",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.102",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "G♭major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.103",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorge Frideric Handel"
+  },
+  {
+    "BWV": "Anh.104",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorge Frideric Handel"
+  },
+  {
+    "BWV": "Anh.105",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorge Frideric Handel"
+  },
+  {
+    "BWV": "Anh.106",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorge Frideric Handel"
+  },
+  {
+    "BWV": "Anh.107",
+    "BC": "—",
+    "Title": "Fugue(on the theme \"B-A-C-H\")",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Andreas Sorge"
+  },
+  {
+    "BWV": "Anh.108",
+    "BC": "—",
+    "Title": "Fugue(on the theme \"B-A-C-H\")",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byGeorg Andreas SorgeorCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "Anh.109",
+    "BC": "—",
+    "Title": "Fugue(on the theme \"B-A-C-H\")",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.110",
+    "BC": "—",
+    "Title": "Fugue(on the theme \"B-A-C-H\")",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; probably composed byGeorg Andreas Sorge"
+  },
+  {
+    "BWV": "Anh.111",
+    "BC": "—",
+    "Title": "Largo and Allegro",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.112",
+    "BC": "—",
+    "Title": "Prelude(Grave)",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Philipp Kirnberger"
+  },
+  {
+    "BWV": "Anh.112a",
+    "BC": "—",
+    "Title": "Notebook II for Anna Magdalena Bach(20):",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "20 doubtful or spurious piees"
+  },
+  {
+    "BWV": "Anh.113",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.114",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byChristian Pezold"
+  },
+  {
+    "BWV": "Anh.115",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byChristian Pezold"
+  },
+  {
+    "BWV": "Anh.116",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.117a",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; see also BWV Anh.117b; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.117b",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "alternate version of BWV Anh.117a; Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.118",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.119",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
+  },
+  {
+    "BWV": "Anh.120",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.121",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "C minor",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.122",
+    "BC": "—",
+    "Title": "March",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/1)"
+  },
+  {
+    "BWV": "Anh.123",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/2)"
+  },
+  {
+    "BWV": "Anh.124",
+    "BC": "—",
+    "Title": "March",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/3)"
+  },
+  {
+    "BWV": "Anh.125",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/4)"
+  },
+  {
+    "BWV": "Anh.126",
+    "BC": "—",
+    "Title": "Musette",
+    "Forces": "kbd",
+    "Key": "D major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.127",
+    "BC": "—",
+    "Title": "March",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "spurious"
+  },
+  {
+    "BWV": "Anh.128",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.129",
+    "BC": "—",
+    "Title": "Harpsichord Sonata",
+    "Forces": "hpd",
+    "Key": "E♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.65/7, H.16)"
+  },
+  {
+    "BWV": "Anh.130",
+    "BC": "—",
+    "Title": "Polonaise",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Adolph Hasse"
+  },
+  {
+    "BWV": "Anh.131",
+    "BC": "—",
+    "Title": "March",
+    "Forces": "kbd",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Christian Bach(W.A22); incomplete"
+  },
+  {
+    "BWV": "Anh.132",
+    "BC": "—",
+    "Title": "Minuet",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "1725",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.133–150",
+    "BC": "—",
+    "Title": "Pieces for a Musical Clock(18)",
+    "Forces": "morg",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byWilhelm Friedemann Bach(F.207)"
+  },
+  {
+    "BWV": "Anh.151",
+    "BC": "—",
+    "Title": "Concerto",
+    "Forces": "kbd",
+    "Key": "C major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.152",
+    "BC": "—",
+    "Title": "Concerto",
+    "Forces": "kbd",
+    "Key": "G major",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.153",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn bc",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.154",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn kbd",
+    "Key": "E♭major",
+    "Date": "?",
+    "Genre": "Chamber",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.155",
+    "BC": "—",
+    "Title": "Concerto",
+    "Forces": "str bc kbd",
+    "Key": "A major",
+    "Date": "?",
+    "Genre": "Orchestral",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.156",
+    "BC": "—",
+    "Title": "Herr Christ, der einge Gottessohn",
+    "Forces": "ch str bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:732)"
+  },
+  {
+    "BWV": "Anh.157",
+    "BC": "—",
+    "Title": "Ich habe Lust zu scheiden",
+    "Forces": "ch orch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:836)"
+  },
+  {
+    "BWV": "Anh.158",
+    "BC": "—",
+    "Title": "Andrò dall' colle aI Prato",
+    "Forces": "v fl str bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Christian Bach(part of the operaOrione, ossia Diana vendicata, W.G4)"
+  },
+  {
+    "BWV": "Anh.159",
+    "BC": "C9",
+    "Title": "Ich lasse dich nicht, du segnest mich denn",
+    "Forces": "2ch",
+    "Key": "",
+    "Date": "1713?",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1165. Formerly attributed toJohann Christoph Bach"
+  },
+  {
+    "BWV": "Anh.160",
+    "BC": "C7",
+    "Title": "Jauchzet dem Herrn, alle Welt",
+    "Forces": "2ch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 8:10)"
+  },
+  {
+    "BWV": "Anh.161",
+    "BC": "—",
+    "Title": "Kündlich groß ist das gottselige Geheimnis",
+    "Forces": "2ch (strings, continuo?)",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byKarl Heinrich Graun(GraunWV 10)"
+  },
+  {
+    "BWV": "Anh.162",
+    "BC": "—",
+    "Title": "Lob und Ehre und Weisheit und Dank",
+    "Forces": "2ch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed by Georg Gottfried Wagner"
+  },
+  {
+    "BWV": "Anh.163",
+    "BC": "—",
+    "Title": "Merk auf, mein Herz und sieh dorthin",
+    "Forces": "2ch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Christoph Bach"
+  },
+  {
+    "BWV": "Anh.164",
+    "BC": "—",
+    "Title": "Nun danket alle Gott",
+    "Forces": "ch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Christoph Altnikol"
+  },
+  {
+    "BWV": "Anh.165",
+    "BC": "—",
+    "Title": "Unser Wandel ist im Himmel",
+    "Forces": "ch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Ernst Bach"
+  },
+  {
+    "BWV": "Anh.166",
+    "BC": "—",
+    "Title": "Mass",
+    "Forces": "ch str bc",
+    "Key": "E minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Ludwig Bach"
+  },
+  {
+    "BWV": "Anh.167",
+    "BC": "—",
+    "Title": "Mass",
+    "Forces": "4vv ch orch",
+    "Key": "G major",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Ludwig BachorAntonio Lotti"
+  },
+  {
+    "BWV": "Anh.168",
+    "BC": "—",
+    "Title": "Kyrie",
+    "Forces": "4vv str",
+    "Key": "G minor",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byWilhelm Friedemann Bach(F.100)"
+  },
+  {
+    "BWV": "Anh.169",
+    "BC": "—",
+    "Title": "Erbauliche Gedanken auf den Gruenen Donnerstag und Charfreitag ueber den Leidenden Jesum",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1725?",
+    "Genre": "Vocal",
+    "Notes": "music lost; probably never composed"
+  },
+  {
+    "BWV": "Anh.170",
+    "BC": "A138",
+    "Title": "Welt ade, ich bin dein müde",
+    "Forces": "ch",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Vocal",
+    "Notes": "spurious; composed byJohann Rosenmüller"
+  },
+  {
+    "BWV": "Anh.171",
+    "BC": "—",
+    "Title": "Christ lag in Todesbanden",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Pachelbel"
+  },
+  {
+    "BWV": "Anh.172",
+    "BC": "—",
+    "Title": "Herr Jesu Christ, dich zu uns wend",
+    "Forces": "org",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "Anh.173–176",
+    "BC": "—",
+    "Title": "Inventions(4)",
+    "Forces": "vn bc",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byFrancesco Antonio Bonporti(Nos.2, 5, 6, 7 from Op.10)"
+  },
+  {
+    "BWV": "Anh.173",
+    "BC": "—",
+    "Title": "Invention in B minor",
+    "Forces": "vn bc",
+    "Key": "B minor",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.2 from Op.10)"
+  },
+  {
+    "BWV": "Anh.174",
+    "BC": "—",
+    "Title": "Invention in B-flat major",
+    "Forces": "vn bc",
+    "Key": "B♭major",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.5 from Op.10)"
+  },
+  {
+    "BWV": "Anh.175",
+    "BC": "—",
+    "Title": "Invention in C minor",
+    "Forces": "vn bc",
+    "Key": "C minor",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.6 from Op.10)"
+  },
+  {
+    "BWV": "Anh.176",
+    "BC": "—",
+    "Title": "Invention in D major",
+    "Forces": "vn bc",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.7 from Op.10)"
+  },
+  {
+    "BWV": "Anh.177",
+    "BC": "—",
+    "Title": "Prelude and Fugue",
+    "Forces": "kbd",
+    "Key": "E♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Christoph Bach"
+  },
+  {
+    "BWV": "Anh.178",
+    "BC": "—",
+    "Title": "Toccata quasi Fantasia con Fuge",
+    "Forces": "org",
+    "Key": "A major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composer uncertain"
+  },
+  {
+    "BWV": "Anh.179",
+    "BC": "—",
+    "Title": "Fantasia durch alle Tonarten gehend",
+    "Forces": "kbd",
+    "Key": "",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann David Heinichen"
+  },
+  {
+    "BWV": "Anh.180",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Peter Kellner"
+  },
+  {
+    "BWV": "Anh.181",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byJohann Ludwig Krebs"
+  },
+  {
+    "BWV": "Anh.182",
+    "BC": "—",
+    "Title": "Passacaglia",
+    "Forces": "kbd",
+    "Key": "D minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byChristian Friedrich Witt"
+  },
+  {
+    "BWV": "Anh.183",
+    "BC": "—",
+    "Title": "Rondo",
+    "Forces": "kbd",
+    "Key": "B♭major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "inNotebook II for Anna Magdalena Bach; spurious; composed byFrançois Couperin"
+  },
+  {
+    "BWV": "Anh.184",
+    "BC": "—",
+    "Title": "Violin Sonata",
+    "Forces": "vn bc",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byCarlo Zuccari(Op.1 No.10)"
+  },
+  {
+    "BWV": "Anh.185",
+    "BC": "—",
+    "Title": "Sonata for 2 Violins",
+    "Forces": "2vn bc",
+    "Key": "D major",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.585)"
+  },
+  {
+    "BWV": "Anh.186",
+    "BC": "—",
+    "Title": "Sonata for 2 Violins",
+    "Forces": "2vn bc",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.154, H.576)"
+  },
+  {
+    "BWV": "Anh.187",
+    "BC": "—",
+    "Title": "Trio",
+    "Forces": "fl bn vn",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Chamber",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.159, H.587)"
+  },
+  {
+    "BWV": "Anh.188",
+    "BC": "—",
+    "Title": "Sonata(Concerto)",
+    "Forces": "2hpd",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "spurious; composed byWilhelm Friedemann Bach(F.10)"
+  },
+  {
+    "BWV": "Anh.189",
+    "BC": "—",
+    "Title": "Harpsichord Concerto",
+    "Forces": "hpd str bc",
+    "Key": "A minor",
+    "Date": "—",
+    "Genre": "Orchestral",
+    "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.1, H.403)"
+  },
+  {
+    "BWV": "Anh.190",
+    "BC": "—",
+    "Title": "Ich bin ein Pilgrim auf der Welt",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "cantata for Easter Monday; fragment only"
+  },
+  {
+    "BWV": "Anh.191",
+    "BC": "—",
+    "Title": "Leb ich oder leb ich icht",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1715?",
+    "Genre": "Vocal",
+    "Notes": "lost"
+  },
+  {
+    "BWV": "Anh.192",
+    "BC": "B02",
+    "Title": "Cantata",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1709",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1137. cantata for the inauguration of Mühlhausen town council; lost"
+  },
+  {
+    "BWV": "Anh.193",
+    "BC": "B09",
+    "Title": "Herrscher des Himmels, König der Ehren",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1740",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1141. Cantata for the inauguration of Leipzig town council; last chorus based on BWV 208, otherwise lost"
+  },
+  {
+    "BWV": "Anh.194",
+    "BC": "—",
+    "Title": "O vergnügte Stunden",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1722",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1154. Cantata for the birthday of Johann August of Anhalt-Zerbst; lost"
+  },
+  {
+    "BWV": "Anh.195",
+    "BC": "—",
+    "Title": "Murmelt nur, ihr heitern Bäche",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1723",
+    "Genre": "Vocal",
+    "Notes": "cantata for Johann Florens Rivinus; lost"
+  },
+  {
+    "BWV": "Anh.196",
+    "BC": "G42",
+    "Title": "Auf, süß entzückende Gewalt",
+    "Forces": "4vv ch orch?",
+    "Key": "",
+    "Date": "1725",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1163. Cantata on the occasion of the wedding of Peter Hohman the Younger; lost"
+  },
+  {
+    "BWV": "Anh.197",
+    "BC": "—",
+    "Title": "Ihr wallenden Wolken",
+    "Forces": "bass orch",
+    "Key": "",
+    "Date": "1721-22",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1150. Cantata as a tribute music in honor of the princely house of Anhalt-Köthen or was for New Year's Day; lost"
+  },
+  {
+    "BWV": "Anh.198",
+    "BC": "—",
+    "Title": "Sinfonia",
+    "Forces": "ch orch",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "cantata for the Feast of St. Michael; fragment only"
+  },
+  {
+    "BWV": "Anh.199",
+    "BC": "—",
+    "Title": "Siehe, eine Jungfrau ist schwanger",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1724",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1135. cantata for the Feast of the Annunciation; lost"
+  },
+  {
+    "BWV": "Anh.200",
+    "BC": "K054",
+    "Title": "O Traurigkeit, o Herzeleid",
+    "Forces": "org",
+    "Key": "",
+    "Date": "1713–15",
+    "Genre": "Keyboard",
+    "Notes": "see BWV 1169. Incomplete"
+  },
+  {
+    "BWV": "Anh.201–204",
+    "BC": "—",
+    "Title": "Chorales(4):",
+    "Forces": "ch",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.201",
+    "BC": "—",
+    "Title": "Du Friedefürst, Herr Jesu Christ",
+    "Forces": "ch",
+    "Key": "G minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.202",
+    "BC": "—",
+    "Title": "Gott has das Evangelium",
+    "Forces": "ch",
+    "Key": "F major",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.203",
+    "BC": "—",
+    "Title": "Och hebe meine Augen auf",
+    "Forces": "ch",
+    "Key": "A minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.204",
+    "BC": "—",
+    "Title": "O Traurigkeit, o Herzeleid",
+    "Forces": "ch",
+    "Key": "B minor",
+    "Date": "?",
+    "Genre": "Vocal",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.205",
+    "BC": "—",
+    "Title": "Fantasia",
+    "Forces": "org",
+    "Key": "C minor",
+    "Date": "1706–10",
+    "Genre": "Keyboard",
+    "Notes": "see BWV 1121."
+  },
+  {
+    "BWV": "Anh.206",
+    "BC": "—",
+    "Title": "Ach bleib mit deiner Gnade",
+    "Forces": "org",
+    "Key": "",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain"
+  },
+  {
+    "BWV": "Anh.207",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E minor",
+    "Date": "?",
+    "Genre": "Keyboard",
+    "Notes": "Bach's authorship uncertain; possibly composed byJohann Peter Kellner"
+  },
+  {
+    "BWV": "Anh.208",
+    "BC": "—",
+    "Title": "Fugue",
+    "Forces": "kbd",
+    "Key": "E♭minor",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "Johann Ernst Eberlin"
+  },
+  {
+    "BWV": "Anh.209",
+    "BC": "—",
+    "Title": "Liebster Gott, vergisst du mich",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1714-17",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1136."
+  },
+  {
+    "BWV": "Anh.210",
+    "BC": "—",
+    "Title": "Wo sind meine Wunderwerke",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1734",
+    "Genre": "Vocal",
+    "Notes": "probably never composed. Music for the farewell party for the Thomasschule rector Johann Matthias Gesner, otherwise music lost."
+  },
+  {
+    "BWV": "Anh.211",
+    "BC": "—",
+    "Title": "Der Herr ist freundlich dem, der auf ihn harret",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1145. Cantata for the wedding of the lawyer and university professor Johann Friedrich Höckner with Jacobina Agnetha Bartholomäus, otherwise music lost"
+  },
+  {
+    "BWV": "Anh.212",
+    "BC": "—",
+    "Title": "Vergnügende Flammen, verdoppelt die Macht",
+    "Forces": "?",
+    "Key": "",
+    "Date": "1729",
+    "Genre": "Vocal",
+    "Notes": "see BWV 1146. Cantata for the wedding of the merchant Christoph Georg Winckler with Caroline Wilhelmine Jöcher, otherwise music lost"
+  },
+  {
+    "BWV": "Anh.213",
+    "BC": "—",
+    "Title": "Concerto",
+    "Forces": "org",
+    "Key": "F major",
+    "Date": "—",
+    "Genre": "Keyboard",
+    "Notes": "see BWV 1168. Arrangement of a concerto byGeorg Philipp Telemann"
+  }
+]

--- a/convert.py
+++ b/convert.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from bs4 import BeautifulSoup
+import json
+
+with open('source.json', 'r', encoding='utf-8') as f:
+    soup = BeautifulSoup(f, 'html.parser')
+
+entries = []
+for row in soup.select('table.wikitable tr'):
+    cells = row.find_all('td')
+    if len(cells) != 8:
+        continue
+    if row.find(['h3', 'h4']):
+        continue
+    text = [cell.get_text(strip=True) for cell in cells]
+    entry = dict(zip(['BWV','BC','Title','Forces','Key','Date','Genre','Notes'], text))
+    entries.append(entry)
+
+with open('bach_works.json', 'w', encoding='utf-8') as f:
+    json.dump(entries, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- add a Python script (`convert.py`) that extracts table data from `source.json`
- generate a JSON dataset (`bach_works.json`) containing parsed entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688504a62634832fbaa5b3ae2554e7c4