### PR TITLE
Update video links with titles and length sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
           const length = parseFloat(lengthStr) || 0;
           const url = `https://youtu.be/${id.trim()}`;
           if (!videoMap[bwv]) videoMap[bwv] = [];
-          videoMap[bwv].push({ url, length, file });
+          videoMap[bwv].push({ url, length, file, title });
         });
       }
       const container = document.getElementById('works');
@@ -147,11 +147,13 @@
             return !isNaN(num) && num >= cat.start && num <= cat.end;
           }).forEach(row => {
             const tr = document.createElement('tr');
-            const entries = videoMap[normalizeBwv(row.BWV)] || [];
+            const entries = (videoMap[normalizeBwv(row.BWV)] || [])
+              .slice()
+              .sort((a, b) => b.length - a.length);
             const videoLinks = entries.map(e => {
               const len = e.length ? `${e.length}s` : '';
               const label = e.file.replace('.csv', '');
-              return `<a href="${e.url}" target="_blank">${label}${len ? ` (${len})` : ''}</a>`;
+              return `<a href="${e.url}" target="_blank">${label}: ${e.title}${len ? ` (${len})` : ''}</a>`;
             }).join('<br>');
             tr.innerHTML = `
               <td>${row.BWV}</td>


### PR DESCRIPTION
## Summary
- include video titles when building the video links
- sort the videos by duration from longest to shortest

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887e0bcd92c832f82fbe2e0461e6ca5