### PR TITLE
Add city column to Bach works table

### DIFF
--- a/bach_works.json
+++ b/bach_works.json
@@ -6,6 +6,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -16,6 +17,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -26,6 +28,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -36,6 +39,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1707–08?, rev. 1724–25",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -46,6 +50,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -56,6 +61,7 @@
     "Forces": "4vv ch orch",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.III adapted in BWV 649"
   },
@@ -66,6 +72,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -76,6 +83,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1724, rev. 1744–47",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -86,6 +94,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -96,6 +105,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.V adapted in BWV 648"
   },
@@ -106,6 +116,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233"
   },
@@ -116,6 +127,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -126,6 +138,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -136,6 +149,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -146,6 +160,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig Bach"
   },
@@ -156,6 +171,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -166,6 +182,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 236"
   },
@@ -176,6 +193,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1713–14, rev. 1724",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233"
   },
@@ -186,6 +204,7 @@
     "Forces": "3vv ch orch",
     "Key": "C major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -196,6 +215,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -206,6 +226,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -216,6 +237,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -226,6 +248,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1723, rev. 1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -236,6 +259,7 @@
     "Forces": "4vv ch orch",
     "Key": "F major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -246,6 +270,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -256,6 +281,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -266,6 +292,7 @@
     "Forces": "4vv ch orch",
     "Key": "C minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -276,6 +303,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "theme used in BWV 231"
   },
@@ -286,6 +314,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Sinfonia (No. 1) based on the Prelude (No. 1) of the Violin Partita No. 3 BWV 1006."
   },
@@ -296,6 +325,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -306,6 +336,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1737",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "dramma per musica"
   },
@@ -316,6 +347,7 @@
     "Forces": "3vv ch orch",
     "Key": "C major",
     "Date": "1715, rev. 1724",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -326,6 +358,7 @@
     "Forces": "2vv ch orch",
     "Key": "E minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -336,6 +369,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -346,6 +380,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1746–47",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "adapted from BWV 34a"
   },
@@ -356,6 +391,7 @@
     "Forces": "4vv ch (orch?)",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost; rev. as BWV 34"
   },
@@ -366,6 +402,7 @@
     "Forces": "v orch",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on a lost oboe concerto (see BWV 1059R)"
   },
@@ -376,6 +413,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1725–30?, rev. 1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 36c"
   },
@@ -386,6 +424,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV.36c; lost"
   },
@@ -396,6 +435,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -406,6 +446,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "rev. as BWV.36"
   },
@@ -416,6 +457,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -426,6 +468,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -436,6 +479,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -446,6 +490,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233"
   },
@@ -456,6 +501,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -466,6 +512,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -476,6 +523,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -486,6 +534,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -496,6 +545,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -506,6 +556,7 @@
     "Forces": "3vv ch orch",
     "Key": "D minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -516,6 +567,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -526,6 +578,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -536,6 +589,7 @@
     "Forces": "2vv orch",
     "Key": "E major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "sinfonia based on a lost oboe concerto (see BWV 1053R)"
   },
@@ -546,6 +600,7 @@
     "Forces": "2ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -556,6 +611,7 @@
     "Forces": "v tpt str bc",
     "Key": "C major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -566,6 +622,7 @@
     "Forces": "v ch orch",
     "Key": "F major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -576,6 +633,7 @@
     "Forces": "v perc org str",
     "Key": "E major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byMelchior Hoffmann"
   },
@@ -586,6 +644,7 @@
     "Forces": "v str bc",
     "Key": "E♭major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "partly rev. in BWV 247"
   },
@@ -596,6 +655,7 @@
     "Forces": "v ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -606,6 +666,7 @@
     "Forces": "v ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -616,6 +677,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -626,6 +688,7 @@
     "Forces": "2vv orch",
     "Key": "C major",
     "Date": "1727, rev. 1733–34?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -636,6 +699,7 @@
     "Forces": "2vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 74"
   },
@@ -646,6 +710,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -656,6 +721,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -666,6 +732,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -676,6 +743,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1714–15, rev. 1729?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -686,6 +754,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -696,6 +765,7 @@
     "Forces": "2vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -706,6 +776,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 66a"
   },
@@ -716,6 +787,7 @@
     "Forces": "2vv ch orch",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "lost; rev. as BWV 66"
   },
@@ -726,6 +798,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234"
   },
@@ -736,6 +809,7 @@
     "Forces": "2vv ch orch",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -746,6 +820,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1742–48",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 69a"
   },
@@ -756,6 +831,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 69"
   },
@@ -766,6 +842,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 70a"
   },
@@ -776,6 +853,7 @@
     "Forces": "",
     "Key": "C major",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "text not lost, but music survives in a few individual parts; rev. as BWV 70"
   },
@@ -786,6 +864,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -796,6 +875,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 235"
   },
@@ -806,6 +886,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1724, rev. 1730–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -816,6 +897,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 59"
   },
@@ -826,6 +908,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -836,6 +919,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -846,6 +930,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version; partly re-used in BWV 528"
   },
@@ -856,6 +941,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -866,6 +952,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -876,6 +963,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234, BWV 236"
   },
@@ -886,6 +974,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1727–31, rev. 1744–47?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 80a, 80b; 1st version"
   },
@@ -896,6 +985,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "lost; rev. in BWV 80"
   },
@@ -906,6 +996,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "fragment only; rev. in BWV 80"
   },
@@ -916,6 +1007,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -926,6 +1018,7 @@
     "Forces": "v ob str bc",
     "Key": "C minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -936,6 +1029,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -946,6 +1040,7 @@
     "Forces": "v ch orch",
     "Key": "E minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -956,6 +1051,7 @@
     "Forces": "4vv ch orch",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -966,6 +1062,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -976,6 +1073,7 @@
     "Forces": "3vv ch orch",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -986,6 +1084,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -996,6 +1095,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1006,6 +1106,7 @@
     "Forces": "3vv ch orch",
     "Key": "D minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1016,6 +1117,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1026,6 +1128,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1036,6 +1139,7 @@
     "Forces": "4vv ch 2ob str bc",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.IV adapted in BWV 647"
   },
@@ -1046,6 +1150,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1056,6 +1161,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1066,6 +1172,7 @@
     "Forces": "4vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1076,6 +1183,7 @@
     "Forces": "4vv ch orch",
     "Key": "B♭major",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1086,6 +1194,7 @@
     "Forces": "4vv ch orch",
     "Key": "B♭major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1096,6 +1205,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1106,6 +1216,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1116,6 +1227,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1126,6 +1238,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233, BWV 235"
   },
@@ -1136,6 +1249,7 @@
     "Forces": "2vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1146,6 +1260,7 @@
     "Forces": "2vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1156,6 +1271,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1166,6 +1282,7 @@
     "Forces": "2vv ch orch",
     "Key": "E♭major",
     "Date": "1707–08?",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1176,6 +1293,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1186,6 +1304,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1196,6 +1315,7 @@
     "Forces": "2vv ch orch",
     "Key": "D minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1206,6 +1326,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1216,6 +1337,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1226,6 +1348,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1236,6 +1359,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1246,6 +1370,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1256,6 +1381,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1266,6 +1392,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1276,6 +1403,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1728–31?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1286,6 +1414,7 @@
     "Forces": "ch orch",
     "Key": "B♭major",
     "Date": "1736–37, rev. 1746–47?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1296,6 +1425,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1306,6 +1436,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1728–29?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 120a,  120b"
   },
@@ -1316,6 +1447,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1729?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 120; partly lost"
   },
@@ -1326,6 +1458,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -1336,6 +1469,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1346,6 +1480,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1356,6 +1491,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1366,6 +1502,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1376,6 +1513,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1386,6 +1524,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1396,6 +1535,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1406,6 +1546,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1416,6 +1557,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1426,6 +1568,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1436,6 +1579,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1707–08",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1446,6 +1590,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; arr. from the finale of BWV 131"
   },
@@ -1456,6 +1601,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1466,6 +1612,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1476,6 +1623,7 @@
     "Forces": "2vv ch orch",
     "Key": "B♭major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 134a"
   },
@@ -1486,6 +1634,7 @@
     "Forces": "2vv ch orch",
     "Key": "B♭major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 134"
   },
@@ -1496,6 +1645,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1506,6 +1656,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234"
   },
@@ -1516,6 +1667,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.II adapted in BWV 650"
   },
@@ -1526,6 +1678,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 236"
   },
@@ -1536,6 +1689,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1546,6 +1700,7 @@
     "Forces": "3vv ch orch",
     "Key": "E♭major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.IV adapted in BWV 645"
   },
@@ -1556,6 +1711,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann"
   },
@@ -1566,6 +1722,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; probably compoed byJohann Kuhnau"
   },
@@ -1576,6 +1733,7 @@
     "Forces": "3vv ch orch",
     "Key": "B♭major",
     "Date": "1708–14",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -1586,6 +1744,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1596,6 +1755,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1606,6 +1766,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on a lost violin concerto (see BWV 1052R)"
   },
@@ -1616,6 +1777,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 147a"
   },
@@ -1626,6 +1788,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "rext is not lost, but only the first four sheets of the musical score survives; rev. as BWV 147"
   },
@@ -1636,6 +1799,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1646,6 +1810,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1656,6 +1821,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1706",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1666,6 +1832,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1726, rev. 1727?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1676,6 +1843,7 @@
     "Forces": "2vv orch",
     "Key": "",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1686,6 +1854,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1696,6 +1865,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1706,6 +1876,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1716,6 +1887,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "sinfonia based on BWV 1056"
   },
@@ -1726,6 +1898,7 @@
     "Forces": "2vv ch orch",
     "Key": "B minor",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 157a"
   },
@@ -1736,6 +1909,7 @@
     "Forces": "2vv ch orch",
     "Key": "B minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 157"
   },
@@ -1746,6 +1920,7 @@
     "Forces": "v ch ob vn bc",
     "Key": "D major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 158a"
   },
@@ -1756,6 +1931,7 @@
     "Forces": "v ch ob vn bc",
     "Key": "D major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; rev. as BWV 158"
   },
@@ -1766,6 +1942,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1776,6 +1953,7 @@
     "Forces": "v bn vn bc",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:877)"
   },
@@ -1786,6 +1964,7 @@
     "Forces": "2vv ch orch",
     "Key": "C major",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1796,6 +1975,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -1806,6 +1986,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1816,6 +1997,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1826,6 +2008,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1836,6 +2019,7 @@
     "Forces": "3vv ch orch",
     "Key": "B♭major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -1846,6 +2030,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1856,6 +2041,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1866,6 +2052,7 @@
     "Forces": "v ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on a lost oboe concerto (see BWV 1053R)"
   },
@@ -1876,6 +2063,7 @@
     "Forces": "v orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1886,6 +2074,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1728?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1896,6 +2085,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -1906,6 +2096,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version"
   },
@@ -1916,6 +2107,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 173a"
   },
@@ -1926,6 +2118,7 @@
     "Forces": "2vv orch",
     "Key": "D major",
     "Date": "1717–22?",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 173"
   },
@@ -1936,6 +2129,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Sinfonia (No. 1) based on the 1st movt. of the Brandenburg Concerto No.3 BWV 1048."
   },
@@ -1946,6 +2140,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1956,6 +2151,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1966,6 +2162,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1976,6 +2173,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1986,6 +2184,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234, BWV 236"
   },
@@ -1996,6 +2195,7 @@
     "Forces": "4vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2006,6 +2206,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1724, rev. 1743–46",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2016,6 +2217,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -2026,6 +2228,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version"
   },
@@ -2036,6 +2239,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2046,6 +2250,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 184a"
   },
@@ -2056,6 +2261,7 @@
     "Forces": "",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "lost; possibly the same as BWV Anh.8; rev. as BWV 184"
   },
@@ -2066,6 +2272,7 @@
     "Forces": "4vv ch orch",
     "Key": "F♯minor",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2076,6 +2283,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 186a"
   },
@@ -2086,6 +2294,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "text not lost, but music survives in a few individual parts; rev. as BWV 186"
   },
@@ -2096,6 +2305,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "parts re-used in BWV 235"
   },
@@ -2106,6 +2316,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "sinfonia based on a lost violin concerto (see BWV 1052R)"
   },
@@ -2116,6 +2327,7 @@
     "Forces": "v orch",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byMelchior Hoffmann"
   },
@@ -2126,6 +2338,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost; rev. as BWV 190a"
   },
@@ -2136,6 +2349,7 @@
     "Forces": "",
     "Key": "D major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2146,6 +2360,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1741–45",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 232/1"
   },
@@ -2156,6 +2371,7 @@
     "Forces": "2vv ch orch",
     "Key": "G major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost"
   },
@@ -2166,6 +2382,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2176,6 +2393,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2186,6 +2404,7 @@
     "Forces": "3vv ch orch",
     "Key": "B♭major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 194a"
   },
@@ -2196,6 +2415,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost; rev. as BWV 194"
   },
@@ -2206,6 +2426,7 @@
     "Forces": "",
     "Key": "D major",
     "Date": "1727–31, rev. 1742, 1748–49",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost"
   },
@@ -2216,6 +2437,7 @@
     "Forces": "3vv ch orch",
     "Key": "C major",
     "Date": "1707–08",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2226,6 +2448,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1736–37",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 197a"
   },
@@ -2236,6 +2459,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 197; partly lost"
   },
@@ -2246,6 +2470,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 244a, BWV 247"
   },
@@ -2256,6 +2481,7 @@
     "Forces": "v orch",
     "Key": "C minor",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2266,6 +2492,7 @@
     "Forces": "v 2vn bc",
     "Key": "E major",
     "Date": "1742–43",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete (aria only)"
   },
@@ -2276,6 +2503,7 @@
     "Forces": "6vv ch orch",
     "Key": "D major",
     "Date": "1729?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2286,6 +2514,7 @@
     "Forces": "v ob str bc",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2296,6 +2525,7 @@
     "Forces": "v hpd",
     "Key": "A minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -2306,6 +2536,7 @@
     "Forces": "v orch",
     "Key": "B♭major",
     "Date": "1726–27",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2316,6 +2547,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "dramma per musica, for the birthday of Professor Augustus Friedrich Müller; parts re-used in BWV 205a"
   },
@@ -2326,6 +2558,7 @@
     "Forces": "",
     "Key": "D major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2336,6 +2569,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -2346,6 +2580,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version"
   },
@@ -2356,6 +2591,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2366,6 +2602,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2376,6 +2613,7 @@
     "Forces": "4vv orch",
     "Key": "F major",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "1st version of BWV 208/2; partly re-used in BWV 208a, BWV Anh.193"
   },
@@ -2386,6 +2624,7 @@
     "Forces": "4vv orch",
     "Key": "F major",
     "Date": "1716?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 208/1"
   },
@@ -2396,6 +2635,7 @@
     "Forces": "",
     "Key": "F major",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the nameday of King August III; based on BWV 208; lost"
   },
@@ -2406,6 +2646,7 @@
     "Forces": "v fl str bc",
     "Key": "B minor",
     "Date": "1729?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2416,6 +2657,7 @@
     "Forces": "v orch",
     "Key": "A major",
     "Date": "1738–41?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 210?"
   },
@@ -2426,6 +2668,7 @@
     "Forces": "",
     "Key": "A major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; based on BWV 210?"
   },
@@ -2436,6 +2679,7 @@
     "Forces": "3vv orch",
     "Key": "G major",
     "Date": "1732–34",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2446,6 +2690,7 @@
     "Forces": "2vv orch",
     "Key": "A major",
     "Date": "1742",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2456,6 +2701,7 @@
     "Forces": "5vv ch orch",
     "Key": "F major",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 248/1–5"
   },
@@ -2466,6 +2712,7 @@
     "Forces": "4vv orch",
     "Key": "D major",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2476,6 +2723,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 248/1–5"
   },
@@ -2486,6 +2734,7 @@
     "Forces": "2vv (orch?)",
     "Key": "C major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2496,6 +2745,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2506,6 +2756,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; probably composed by Johann Christoph Altnikol"
   },
@@ -2516,6 +2767,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:634)"
   },
@@ -2526,6 +2778,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:1328)"
   },
@@ -2536,6 +2789,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composer unidentified"
   },
@@ -2546,6 +2800,7 @@
     "Forces": "2vv orch",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composer unidentified"
   },
@@ -2556,6 +2811,7 @@
     "Forces": "3vv ch org str",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ernst Bach"
   },
@@ -2566,6 +2822,7 @@
     "Forces": "",
     "Key": "B♭major",
     "Date": "1707–08?",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2576,6 +2833,7 @@
     "Forces": "",
     "Key": "D minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; spurious; probably composed byCarl Philipp Emanuel Bach"
   },
@@ -2586,6 +2844,7 @@
     "Forces": "2ch",
     "Key": "B♭major",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2596,6 +2855,7 @@
     "Forces": "2ch orch",
     "Key": "B♭major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2606,6 +2866,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2616,6 +2877,7 @@
     "Forces": "2ch",
     "Key": "A major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "A major"
   },
@@ -2626,6 +2888,7 @@
     "Forces": "2ch",
     "Key": "G minor",
     "Date": "1723–24?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2636,6 +2899,7 @@
     "Forces": "ch bc",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2646,6 +2910,7 @@
     "Forces": "2ch",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "based partly on BWV 28 and music byGeorg Philipp Telemann; spurious; probably composed by Johann Gottlob Harrer"
   },
@@ -2656,6 +2921,7 @@
     "Forces": "5vv ch orch",
     "Key": "B minor",
     "Date": "1747–49",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "assembled from previous compositions"
   },
@@ -2666,6 +2932,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 233a, BWV 11, BWV 40, BWV 102, BWV Anh.18"
   },
@@ -2676,6 +2943,7 @@
     "Forces": "ch bc",
     "Key": "F major",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "rev. in BWV 233"
   },
@@ -2686,6 +2954,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 67, BWV 79, BWV 136, BWV 179"
   },
@@ -2696,6 +2965,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 72, BWV 102, BWV 187"
   },
@@ -2706,6 +2976,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 17, BWV 79, BWV 138, BWV 179"
   },
@@ -2716,6 +2987,7 @@
     "Forces": "ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2726,6 +2998,7 @@
     "Forces": "ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2736,6 +3009,7 @@
     "Forces": "ch str bc",
     "Key": "D minor",
     "Date": "1738–41?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2746,6 +3020,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1742?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -2756,6 +3031,7 @@
     "Forces": "2ch orch",
     "Key": "D major",
     "Date": "1747–48",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "arr. of theSanctusfrom theMissa superbaby Johann Kasper Kerll"
   },
@@ -2766,6 +3042,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1727–32",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "adapted from a Mass in C minor byFrancesco Durante(see BWV Anh.26)"
   },
@@ -2776,6 +3053,7 @@
     "Forces": "5vv ch orch",
     "Key": "D major",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 243a"
   },
@@ -2786,6 +3064,7 @@
     "Forces": "5vv ch orch",
     "Key": "E♭major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version of BWV 243"
   },
@@ -2796,6 +3075,7 @@
     "Forces": "vv 2ch 2orch",
     "Key": "",
     "Date": "1736–42",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 244b"
   },
@@ -2806,6 +3086,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1143. Partly based on BWV 198, BWV 247, BWV 244b; lost"
   },
@@ -2816,6 +3097,7 @@
     "Forces": "v 2ch 2orch",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version of BWV 244; text partly re-used in BWV 244a"
   },
@@ -2826,6 +3108,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1724, rev. 1725–49",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2836,6 +3119,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; probably composed by Johann Melchior Molter"
   },
@@ -2846,6 +3130,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 198, BWV 54; lost, but various modern reconstructions exist; partly rev. in BWV 248?"
   },
@@ -2856,6 +3141,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2866,6 +3152,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2876,6 +3163,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2886,6 +3174,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2896,6 +3185,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2906,6 +3196,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2916,6 +3207,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 248a"
   },
@@ -2926,6 +3218,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; rev. as BWV 248/6"
   },
@@ -2936,6 +3229,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for Easter Sunday; based on BWV.249a; 1st version of BWV 249/2"
   },
@@ -2946,6 +3240,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 249/1"
   },
@@ -2956,6 +3251,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost; rev. as BWV.249/1"
   },
@@ -2966,6 +3262,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2976,6 +3273,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2986,6 +3284,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2996,6 +3295,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3006,6 +3306,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3016,6 +3317,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3026,6 +3328,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3036,6 +3339,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3046,6 +3350,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3056,6 +3361,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3066,6 +3372,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3076,6 +3383,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3086,6 +3394,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3096,6 +3405,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3106,6 +3416,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3116,6 +3427,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3126,6 +3438,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3136,6 +3449,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3146,6 +3460,7 @@
     "Forces": "ch",
     "Key": "G/A♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3156,6 +3471,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3166,6 +3482,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3176,6 +3493,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3186,6 +3504,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3196,6 +3515,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3206,6 +3526,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3216,6 +3537,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3226,6 +3548,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3236,6 +3559,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3246,6 +3570,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3256,6 +3581,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3266,6 +3592,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3276,6 +3603,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3286,6 +3614,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3296,6 +3625,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3306,6 +3636,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3316,6 +3647,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3326,6 +3658,7 @@
     "Forces": "ch",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3336,6 +3669,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3346,6 +3680,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3356,6 +3691,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3366,6 +3702,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3376,6 +3713,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3386,6 +3724,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3396,6 +3735,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3406,6 +3746,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3416,6 +3757,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3426,6 +3768,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3436,6 +3779,7 @@
     "Forces": "ch",
     "Key": "G Mixolydian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3446,6 +3790,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3456,6 +3801,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3466,6 +3812,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3476,6 +3823,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3486,6 +3834,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3496,6 +3845,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3506,6 +3856,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3516,6 +3867,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3526,6 +3878,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3536,6 +3889,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3546,6 +3900,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3556,6 +3911,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3566,6 +3922,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3576,6 +3933,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3586,6 +3944,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3596,6 +3955,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3606,6 +3966,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3616,6 +3977,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3626,6 +3988,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3636,6 +3999,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3646,6 +4010,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3656,6 +4021,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3666,6 +4032,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3676,6 +4043,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3686,6 +4054,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3696,6 +4065,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3706,6 +4076,7 @@
     "Forces": "ch",
     "Key": "F♯minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3716,6 +4087,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3726,6 +4098,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3736,6 +4109,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3746,6 +4120,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3756,6 +4131,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3766,6 +4142,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3776,6 +4153,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3786,6 +4164,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3796,6 +4175,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3806,6 +4186,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3816,6 +4197,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3826,6 +4208,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3836,6 +4219,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3846,6 +4230,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3856,6 +4241,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3866,6 +4252,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3876,6 +4263,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3886,6 +4274,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3896,6 +4285,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3906,6 +4296,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3916,6 +4307,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3926,6 +4318,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3936,6 +4329,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3946,6 +4340,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3956,6 +4351,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3966,6 +4362,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3976,6 +4373,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3986,6 +4384,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3996,6 +4395,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4006,6 +4406,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4016,6 +4417,7 @@
     "Forces": "ch",
     "Key": "B♭Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4026,6 +4428,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4036,6 +4439,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4046,6 +4450,7 @@
     "Forces": "ch",
     "Key": "C Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4056,6 +4461,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4066,6 +4472,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4076,6 +4483,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4086,6 +4494,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4096,6 +4505,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4106,6 +4516,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4116,6 +4527,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4126,6 +4538,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4136,6 +4549,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4146,6 +4560,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4156,6 +4571,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4166,6 +4582,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4176,6 +4593,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4186,6 +4604,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4196,6 +4615,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4206,6 +4626,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4216,6 +4637,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4226,6 +4648,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4236,6 +4659,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4246,6 +4670,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4256,6 +4681,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4266,6 +4692,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4276,6 +4703,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4286,6 +4714,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4296,6 +4725,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4306,6 +4736,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4316,6 +4747,7 @@
     "Forces": "ch",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4326,6 +4758,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4336,6 +4769,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4346,6 +4780,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4356,6 +4791,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4366,6 +4802,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4376,6 +4813,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4386,6 +4824,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4396,6 +4835,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4406,6 +4846,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4416,6 +4857,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4426,6 +4868,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4436,6 +4879,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4446,6 +4890,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4456,6 +4901,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4466,6 +4912,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4476,6 +4923,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4486,6 +4934,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4496,6 +4945,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4506,6 +4956,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4516,6 +4967,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4526,6 +4978,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4536,6 +4989,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4546,6 +5000,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4556,6 +5011,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4566,6 +5022,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4576,6 +5033,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4586,6 +5044,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4596,6 +5055,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4606,6 +5066,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4616,6 +5077,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4626,6 +5088,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4636,6 +5099,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4646,6 +5110,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4656,6 +5121,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4666,6 +5132,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4676,6 +5143,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4686,6 +5154,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4696,6 +5165,7 @@
     "Forces": "ch",
     "Key": "G Mixolydian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4706,6 +5176,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4716,6 +5187,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4726,6 +5198,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4736,6 +5209,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4746,6 +5220,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4756,6 +5231,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4766,6 +5242,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4776,6 +5253,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4786,6 +5264,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4796,6 +5275,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4806,6 +5286,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4816,6 +5297,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4826,6 +5308,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4836,6 +5319,7 @@
     "Forces": "ch",
     "Key": "E major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4846,6 +5330,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4856,6 +5341,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4866,6 +5352,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.831, p.564)"
   },
@@ -4876,6 +5363,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.171, p.114)"
   },
@@ -4886,6 +5374,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.320, p.215)"
   },
@@ -4896,6 +5385,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.570, p.386)"
   },
@@ -4906,6 +5396,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.689, p.473)"
   },
@@ -4916,6 +5407,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.303, p.203)"
   },
@@ -4926,6 +5418,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.355, p.236)"
   },
@@ -4936,6 +5429,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.39, p.24)"
   },
@@ -4946,6 +5440,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.40, p.25)"
   },
@@ -4956,6 +5451,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.43, p.27)"
   },
@@ -4966,6 +5462,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.396, p.258)"
   },
@@ -4976,6 +5473,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.258, p.170)"
   },
@@ -4986,6 +5484,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.13, p.9)"
   },
@@ -4996,6 +5495,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.397, p.259)"
   },
@@ -5006,6 +5506,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.112, p.74)"
   },
@@ -5016,6 +5517,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.187, p.125)"
   },
@@ -5026,6 +5528,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.580, p.396)"
   },
@@ -5036,6 +5539,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.572, p.388)"
   },
@@ -5046,6 +5550,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.847, p.574)"
   },
@@ -5056,6 +5561,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.306, p.206)"
   },
@@ -5066,6 +5572,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.522, p.351)"
   },
@@ -5076,6 +5583,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.647, p.444)"
   },
@@ -5086,6 +5594,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.488, p.325)"
   },
@@ -5096,6 +5605,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.360, p.240)"
   },
@@ -5106,6 +5616,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.78, p.48)"
   },
@@ -5116,6 +5627,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.861, p.584)"
   },
@@ -5126,6 +5638,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.194, p.130)"
   },
@@ -5136,6 +5649,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.657, p.451)"
   },
@@ -5146,6 +5660,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.734, p.502)"
   },
@@ -5156,6 +5671,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.737, p.505)"
   },
@@ -5166,6 +5682,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.195, p.131)"
   },
@@ -5176,6 +5693,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.741, p.509)"
   },
@@ -5186,6 +5704,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.139, p.91)"
   },
@@ -5196,6 +5715,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.119, p.79)"
   },
@@ -5206,6 +5726,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.696, p.478)"
   },
@@ -5216,6 +5737,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.463, p.303)"
   },
@@ -5226,6 +5748,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.333, p.222)"
   },
@@ -5236,6 +5759,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.197, p.133)"
   },
@@ -5246,6 +5770,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.869, p.591)"
   },
@@ -5256,6 +5781,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.868, p.590)"
   },
@@ -5266,6 +5792,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.936, p.638)"
   },
@@ -5276,6 +5803,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.938, p.640)"
   },
@@ -5286,6 +5814,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.281, p.187)"
   },
@@ -5296,6 +5825,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.467, p.306)"
   },
@@ -5306,6 +5836,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.873, p.595)"
   },
@@ -5316,6 +5847,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.874, p.596)"
   },
@@ -5326,6 +5858,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.761, p.521)"
   },
@@ -5336,6 +5869,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.121, p.81)"
   },
@@ -5346,6 +5880,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.283, p.189)"
   },
@@ -5356,6 +5891,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.881, p.601)"
   },
@@ -5366,6 +5902,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.574, p.390)"
   },
@@ -5376,6 +5913,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.700, p.481)"
   },
@@ -5386,6 +5924,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.284, p.190)"
   },
@@ -5396,6 +5935,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.891, p.608)"
   },
@@ -5406,6 +5946,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.203, p.136)"
   },
@@ -5416,6 +5957,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.575, p.392)"
   },
@@ -5426,6 +5968,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.894, p.611)"
   },
@@ -5436,6 +5979,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.472, p.312)"
   },
@@ -5446,6 +5990,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.710, p.488)"
   },
@@ -5456,6 +6001,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.292, p.196)"
   },
@@ -5466,6 +6012,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.293, p.197)"
   },
@@ -5476,6 +6023,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.296, p.199)"
   },
@@ -5486,6 +6034,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "alternative version of BWV 500"
   },
@@ -5496,6 +6045,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.315, p.211)"
   },
@@ -5506,6 +6056,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.901, p.617)"
   },
@@ -5516,6 +6067,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.945, p.646)"
   },
@@ -5526,6 +6078,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.475, p.315)"
   },
@@ -5536,6 +6089,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.627, p.430)"
   },
@@ -5546,6 +6100,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.779, p.553)"
   },
@@ -5556,6 +6111,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.108, p.69)"
   },
@@ -5566,6 +6122,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "composed byStölzelpossibly arr. by Bach"
   },
@@ -5576,6 +6133,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5586,6 +6144,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5596,6 +6155,7 @@
     "Forces": "v bc",
     "Key": "G minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5606,6 +6166,7 @@
     "Forces": "v bc",
     "Key": "E minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5616,6 +6177,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5626,6 +6188,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5636,6 +6199,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see also BWV 515a"
   },
@@ -5646,6 +6210,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "alternative version of BWV 515"
   },
@@ -5656,6 +6221,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5666,6 +6232,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5676,6 +6243,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5686,6 +6254,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5696,6 +6265,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5706,6 +6276,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5716,6 +6287,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5726,6 +6298,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5736,6 +6309,7 @@
     "Forces": "4vv bc",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -5746,6 +6320,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5756,6 +6331,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5766,6 +6342,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "2nd movt. rev. in BWV 1044"
   },
@@ -5776,6 +6353,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "partly based on BWV 76"
   },
@@ -5786,6 +6364,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5796,6 +6375,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5806,6 +6386,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5816,6 +6397,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1708-12?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 532a"
   },
@@ -5826,6 +6408,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 532 No.2"
   },
@@ -5836,6 +6419,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "see also BWV 533a"
   },
@@ -5846,6 +6430,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 533"
   },
@@ -5856,6 +6441,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5866,6 +6452,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 535a"
   },
@@ -5876,6 +6463,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 535; incomplete"
   },
@@ -5886,6 +6474,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 536a"
   },
@@ -5896,6 +6485,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 536; Bach's authorship uncertain"
   },
@@ -5906,6 +6496,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5916,6 +6507,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1712–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5926,6 +6518,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Fugue based on part of BWV 1001"
   },
@@ -5936,6 +6529,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–31",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5946,6 +6540,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1712?, rev. 1724–25",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5956,6 +6551,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1720–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5966,6 +6562,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Fugue based on part of BWV 944. Alternate Prelude to BWV 543a."
   },
@@ -5976,6 +6573,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Early Version of BWV 543."
   },
@@ -5986,6 +6584,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1727–31",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5996,6 +6595,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1712–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 545a, BWV 545b"
   },
@@ -6006,6 +6606,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 545"
   },
@@ -6016,6 +6617,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 545; Bach's authorship is uncertain; possibly composed byJohann Tobias Krebs"
   },
@@ -6026,6 +6628,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1723–29?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6036,6 +6639,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6046,6 +6650,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1727–31",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6056,6 +6661,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 549a"
   },
@@ -6066,6 +6672,7 @@
     "Forces": "org",
     "Key": "D Dorian mode",
     "Date": "1703–07",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 549"
   },
@@ -6076,6 +6683,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6086,6 +6694,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1707?",
+    "City": "Mühlhausen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6096,6 +6705,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1739?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6106,6 +6716,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6116,6 +6727,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6126,6 +6738,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6136,6 +6749,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6146,6 +6760,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6156,6 +6771,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6166,6 +6782,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6176,6 +6793,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6186,6 +6804,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6196,6 +6815,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composer unidentified"
   },
@@ -6206,6 +6826,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1730–45",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Fugue incomplete"
   },
@@ -6216,6 +6837,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1707",
+    "City": "Mühlhausen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6226,6 +6848,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1712?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6236,6 +6859,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6246,6 +6870,7 @@
     "Forces": "org",
     "Key": "E major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; 1st version of BWV 566a"
   },
@@ -6256,6 +6881,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; 2nd version of BWV 566"
   },
@@ -6266,6 +6892,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -6276,6 +6903,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6286,6 +6914,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6296,6 +6925,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1705–08?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6306,6 +6936,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6316,6 +6947,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1712?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6326,6 +6958,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1722?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -6336,6 +6969,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 574a, BWV 574b"
   },
@@ -6346,6 +6980,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 574"
   },
@@ -6356,6 +6991,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 574"
   },
@@ -6366,6 +7002,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6376,6 +7013,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composer unidentified"
   },
@@ -6386,6 +7024,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6396,6 +7035,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1707?",
+    "City": "Mühlhausen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6406,6 +7046,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6416,6 +7057,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6426,6 +7068,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried August Homilius"
   },
@@ -6436,6 +7079,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708–12?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6446,6 +7090,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1723–29?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6456,6 +7101,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6466,6 +7112,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Friedrich Fasch"
   },
@@ -6476,6 +7123,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; based on music byGeorg Philipp Telemann"
   },
@@ -6486,6 +7134,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; based onLes nationsbyFrançois Couperin"
   },
@@ -6496,6 +7145,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6506,6 +7156,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1709?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6516,6 +7167,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "after 1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -6526,6 +7178,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann David Heinichen"
   },
@@ -6536,6 +7189,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of a lost violin concerto by Prince Johann Ernst of Saxe-Weimar; arr. for hpd as BWV 592a"
   },
@@ -6546,6 +7200,7 @@
     "Forces": "hpd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of BWV 592"
   },
@@ -6556,6 +7211,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theConcerto for 2 Violins in A minor, RV 522, byAntonio Vivaldi"
   },
@@ -6566,6 +7222,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in D major, RV 208, byAntonio Vivaldi"
   },
@@ -6576,6 +7233,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of No.4 of the 6 Violiin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar; see also BWV 987"
   },
@@ -6586,6 +7244,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theConcerto for 2 Violins and Cello in D minor, RV 565, byAntonio Vivaldi"
   },
@@ -6596,6 +7255,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "arr. of a concerto by an unidentified composer; Bach's authorship uncertain"
   },
@@ -6606,6 +7266,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1735?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possbily composed byCarl Philipp Emanuel Bach"
   },
@@ -6616,6 +7277,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6626,6 +7288,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6636,6 +7299,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6646,6 +7310,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6656,6 +7321,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6666,6 +7332,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6676,6 +7343,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6686,6 +7354,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6696,6 +7365,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6706,6 +7376,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6716,6 +7387,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6726,6 +7398,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6736,6 +7409,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6746,6 +7420,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6756,6 +7431,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6766,6 +7442,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6776,6 +7453,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6786,6 +7464,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6796,6 +7475,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6806,6 +7486,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6816,6 +7497,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6826,6 +7508,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6836,6 +7519,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6846,6 +7530,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1714-16?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6856,6 +7541,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6866,6 +7552,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6876,6 +7563,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6886,6 +7574,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6896,6 +7585,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6906,6 +7596,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6916,6 +7607,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6926,6 +7618,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6936,6 +7629,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6946,6 +7640,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6956,6 +7651,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6966,6 +7662,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6976,6 +7673,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1727–30",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6986,6 +7684,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6996,6 +7695,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7006,6 +7706,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7016,6 +7717,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7026,6 +7728,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7036,6 +7739,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7046,6 +7750,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7056,6 +7761,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7066,6 +7772,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1710–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7076,6 +7783,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7086,6 +7794,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7096,6 +7805,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7106,6 +7816,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7116,6 +7827,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7126,6 +7838,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7136,6 +7849,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7146,6 +7860,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.IV of BWV 140"
   },
@@ -7156,6 +7871,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7166,6 +7882,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.IV of BWV 93"
   },
@@ -7176,6 +7893,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.V of BWV 10"
   },
@@ -7186,6 +7904,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.III of BWV 6"
   },
@@ -7196,6 +7915,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.II of BWV 137"
   },
@@ -7206,6 +7926,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7216,6 +7937,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7226,6 +7948,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7236,6 +7959,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7246,6 +7970,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7256,6 +7981,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7266,6 +7992,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1719?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7276,6 +8003,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7286,6 +8014,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7296,6 +8025,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7306,6 +8036,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7316,6 +8047,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7326,6 +8058,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7336,6 +8069,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7346,6 +8080,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7356,6 +8091,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7366,6 +8102,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7376,6 +8113,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7386,6 +8124,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7396,6 +8135,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7406,6 +8146,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7416,6 +8157,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7426,6 +8168,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7436,6 +8179,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Ludwig Krebs"
   },
@@ -7446,6 +8190,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7456,6 +8201,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7466,6 +8212,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7476,6 +8223,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7486,6 +8234,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7496,6 +8245,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7506,6 +8256,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1746/47?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7516,6 +8267,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7526,6 +8278,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7536,6 +8289,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7546,6 +8300,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7556,6 +8311,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7566,6 +8322,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7576,6 +8333,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7586,6 +8344,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1749?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7596,6 +8355,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7606,6 +8366,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -7616,6 +8377,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1750",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7626,6 +8388,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7636,6 +8399,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7646,6 +8410,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7656,6 +8421,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7666,6 +8432,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7676,6 +8443,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7686,6 +8454,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7696,6 +8465,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7706,6 +8476,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7716,6 +8487,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Variant. Bach's authorship of this work is doubtful"
   },
@@ -7726,6 +8498,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7736,6 +8509,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7746,6 +8520,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7756,6 +8531,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7766,6 +8542,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7776,6 +8553,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7786,6 +8564,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7796,6 +8575,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Variant. Bach's authorship of this work is doubtful"
   },
@@ -7806,6 +8586,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7816,6 +8597,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7826,6 +8608,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7836,6 +8619,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7846,6 +8630,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7856,6 +8641,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7866,6 +8652,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7876,6 +8663,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7886,6 +8674,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 691"
   },
@@ -7896,6 +8685,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1749?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 691; Bach's authorship uncertain"
   },
@@ -7906,6 +8696,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -7916,6 +8707,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -7926,6 +8718,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -7936,6 +8729,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7946,6 +8740,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7956,6 +8751,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -7966,6 +8762,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7976,6 +8773,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7986,6 +8784,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7996,6 +8795,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8006,6 +8806,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8016,6 +8817,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8026,6 +8828,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8036,6 +8839,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8046,6 +8850,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8056,6 +8861,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8066,6 +8872,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8076,6 +8883,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8086,6 +8894,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1731?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8096,6 +8905,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1731?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8106,6 +8916,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8116,6 +8927,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "spurious; composer unidentfied"
   },
@@ -8126,6 +8938,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byNicolaus Vetter"
   },
@@ -8136,6 +8949,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8146,6 +8960,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8156,6 +8971,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8166,6 +8982,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "Various",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8176,6 +8993,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8186,6 +9004,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1727?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8196,6 +9015,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8206,6 +9026,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8216,6 +9037,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1712–13",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8226,6 +9048,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8236,6 +9059,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Michael Bach"
   },
@@ -8246,6 +9070,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8256,6 +9081,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8266,6 +9092,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8276,6 +9103,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Michael Bach"
   },
@@ -8286,6 +9114,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8296,6 +9125,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8306,6 +9136,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8316,6 +9147,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8326,6 +9158,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8336,6 +9169,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8346,6 +9180,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8356,6 +9191,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8366,6 +9202,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8376,6 +9213,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8386,6 +9224,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -8396,6 +9235,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8406,6 +9246,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8416,6 +9257,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8426,6 +9268,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8436,6 +9279,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8446,6 +9290,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8456,6 +9301,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8466,6 +9312,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8476,6 +9323,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -8486,6 +9334,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8496,6 +9345,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1733?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8506,6 +9356,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8516,6 +9367,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Ludwig Krebs"
   },
@@ -8526,6 +9378,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; probably composed byCarl Philipp Emanuel Bach"
   },
@@ -8536,6 +9389,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Caspar Ferdinand Fischer"
   },
@@ -8546,6 +9400,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1731–40?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8556,6 +9411,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther; see also BWV 748a"
   },
@@ -8566,6 +9422,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "variant of BWV 748; spurious; composed byJohann Gottfried Walther"
   },
@@ -8576,6 +9433,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain, possibly composed byJohann Christoph BachorGeorg Philipp Telemann"
   },
@@ -8586,6 +9444,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8596,6 +9455,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Michael Bach"
   },
@@ -8606,6 +9466,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8616,6 +9477,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -8626,6 +9488,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8636,6 +9499,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8646,6 +9510,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8656,6 +9521,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8666,6 +9532,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8676,6 +9543,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried August Homilius; see also BWV Anh.74"
   },
@@ -8686,6 +9554,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Böhm"
   },
@@ -8696,6 +9565,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Böhm"
   },
@@ -8706,6 +9576,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8716,6 +9587,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1737?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8726,6 +9598,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -8736,6 +9609,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8746,6 +9620,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8756,6 +9631,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8766,6 +9642,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8776,6 +9653,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 769a"
   },
@@ -8786,6 +9664,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 769"
   },
@@ -8796,6 +9675,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8806,6 +9686,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byNicolaus Vetter"
   },
@@ -8816,6 +9697,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8826,6 +9708,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 772a"
   },
@@ -8836,6 +9719,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 772; Bach's authorship uncertain"
   },
@@ -8846,6 +9730,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8856,6 +9741,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8866,6 +9752,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8876,6 +9763,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8886,6 +9774,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8896,6 +9785,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8906,6 +9796,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8916,6 +9807,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8926,6 +9818,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8936,6 +9829,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8946,6 +9840,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8956,6 +9851,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8966,6 +9862,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8976,6 +9873,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8986,6 +9884,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8996,6 +9895,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9006,6 +9906,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9016,6 +9917,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9026,6 +9928,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9036,6 +9939,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9046,6 +9950,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9056,6 +9961,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9066,6 +9972,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9076,6 +9983,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9086,6 +9994,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9096,6 +10005,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9106,6 +10016,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9116,6 +10027,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9126,6 +10038,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9136,6 +10049,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9146,6 +10060,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.23 inClavier-Übung III"
   },
@@ -9156,6 +10071,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.24 inClavier-Übung III"
   },
@@ -9166,6 +10082,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.25 inClavier-Übung III"
   },
@@ -9176,6 +10093,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.26 inClavier-Übung III"
   },
@@ -9186,6 +10104,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 806a"
   },
@@ -9196,6 +10115,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1714–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 806"
   },
@@ -9206,6 +10126,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9216,6 +10137,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9226,6 +10148,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9236,6 +10159,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9246,6 +10170,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9256,6 +10181,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9266,6 +10192,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 813a"
   },
@@ -9276,6 +10203,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 813"
   },
@@ -9286,6 +10214,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 814a"
   },
@@ -9296,6 +10225,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 814"
   },
@@ -9306,6 +10236,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 815a"
   },
@@ -9316,6 +10247,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 815"
   },
@@ -9326,6 +10258,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9336,6 +10269,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9346,6 +10280,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 818"
   },
@@ -9356,6 +10291,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 818"
   },
@@ -9366,6 +10302,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 819"
   },
@@ -9376,6 +10313,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1725–28?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 819"
   },
@@ -9386,6 +10324,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9396,6 +10335,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9406,6 +10346,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9416,6 +10357,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -9426,6 +10368,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 32:14)"
   },
@@ -9436,6 +10379,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.1 inClavier-Übung I"
   },
@@ -9446,6 +10390,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.2 inClavier-Übung I"
   },
@@ -9456,6 +10401,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1725–27",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.3 inClavier-Übung I"
   },
@@ -9466,6 +10412,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.4 inClavier-Übung I"
   },
@@ -9476,6 +10423,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.5 inClavier-Übung I"
   },
@@ -9486,6 +10434,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1725–30",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.6 inClavier-Übung I"
   },
@@ -9496,6 +10445,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "2nd version of BWV 831a; No.2 inClavier-Übung II"
   },
@@ -9506,6 +10456,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "1st version of BWV 831"
   },
@@ -9516,6 +10467,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9526,6 +10478,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1708–14?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byBernardo Pasquini"
   },
@@ -9536,6 +10489,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9546,6 +10500,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger"
   },
@@ -9556,6 +10511,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–22",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "composed withWilhelm Friedemann Bach"
   },
@@ -9566,6 +10522,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–22",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "composed withWilhelm Friedemann Bach; incomplete"
   },
@@ -9576,6 +10533,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristoph Graupner(GWV 849/2–3)"
   },
@@ -9586,6 +10544,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1735?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9596,6 +10555,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 32:13)"
   },
@@ -9606,6 +10566,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Part of the3 Minuets"
   },
@@ -9616,6 +10577,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Part of the3 Minuets"
   },
@@ -9626,6 +10588,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Part of the3 Minuets"
   },
@@ -9636,6 +10599,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach; see also BWV 844a"
   },
@@ -9646,6 +10610,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 844; Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -9656,6 +10621,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9666,6 +10632,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9676,6 +10643,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 846a"
   },
@@ -9686,6 +10654,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 846"
   },
@@ -9696,6 +10665,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 847a"
   },
@@ -9706,6 +10676,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 847"
   },
@@ -9716,6 +10687,7 @@
     "Forces": "kbd",
     "Key": "C♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 848a"
   },
@@ -9726,6 +10698,7 @@
     "Forces": "kbd",
     "Key": "C♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 848"
   },
@@ -9736,6 +10709,7 @@
     "Forces": "kbd",
     "Key": "C♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 849a"
   },
@@ -9746,6 +10720,7 @@
     "Forces": "kbd",
     "Key": "C♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 849"
   },
@@ -9756,6 +10731,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 850a"
   },
@@ -9766,6 +10742,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 850"
   },
@@ -9776,6 +10753,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 851a"
   },
@@ -9786,6 +10764,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 851"
   },
@@ -9796,6 +10775,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 852a"
   },
@@ -9806,6 +10786,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 852"
   },
@@ -9816,6 +10797,7 @@
     "Forces": "kbd",
     "Key": "E♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 853a"
   },
@@ -9826,6 +10808,7 @@
     "Forces": "kbd",
     "Key": "E♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 853"
   },
@@ -9836,6 +10819,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 854a"
   },
@@ -9846,6 +10830,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 854"
   },
@@ -9856,6 +10841,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 855a"
   },
@@ -9866,6 +10852,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 855"
   },
@@ -9876,6 +10863,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 856a"
   },
@@ -9886,6 +10874,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 856"
   },
@@ -9896,6 +10885,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 857a"
   },
@@ -9906,6 +10896,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 857"
   },
@@ -9916,6 +10907,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 858a"
   },
@@ -9926,6 +10918,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 858"
   },
@@ -9936,6 +10929,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 859a"
   },
@@ -9946,6 +10940,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 859"
   },
@@ -9956,6 +10951,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 860a"
   },
@@ -9966,6 +10962,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 860"
   },
@@ -9976,6 +10973,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 861a"
   },
@@ -9986,6 +10984,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 861"
   },
@@ -9996,6 +10995,7 @@
     "Forces": "kbd",
     "Key": "A♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 862a"
   },
@@ -10006,6 +11006,7 @@
     "Forces": "kbd",
     "Key": "A♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 862"
   },
@@ -10016,6 +11017,7 @@
     "Forces": "kbd",
     "Key": "G♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 863a"
   },
@@ -10026,6 +11028,7 @@
     "Forces": "kbd",
     "Key": "G♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 863"
   },
@@ -10036,6 +11039,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 864a"
   },
@@ -10046,6 +11050,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 864"
   },
@@ -10056,6 +11061,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 865a"
   },
@@ -10066,6 +11072,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 865"
   },
@@ -10076,6 +11083,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 866a"
   },
@@ -10086,6 +11094,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 866"
   },
@@ -10096,6 +11105,7 @@
     "Forces": "kbd",
     "Key": "B♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 867a"
   },
@@ -10106,6 +11116,7 @@
     "Forces": "kbd",
     "Key": "B♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 867"
   },
@@ -10116,6 +11127,7 @@
     "Forces": "kbd",
     "Key": "B major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 868a"
   },
@@ -10126,6 +11138,7 @@
     "Forces": "kbd",
     "Key": "B major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 868"
   },
@@ -10136,6 +11149,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 869a"
   },
@@ -10146,6 +11160,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 869"
   },
@@ -10156,6 +11171,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10166,6 +11182,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 870a, 870b"
   },
@@ -10176,6 +11193,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 870"
   },
@@ -10186,6 +11204,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 870"
   },
@@ -10196,6 +11215,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10206,6 +11226,7 @@
     "Forces": "kbd",
     "Key": "C♯major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 872a"
   },
@@ -10216,6 +11237,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 872"
   },
@@ -10226,6 +11248,7 @@
     "Forces": "kbd",
     "Key": "C♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10236,6 +11259,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10246,6 +11270,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 875a"
   },
@@ -10256,6 +11281,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 875"
   },
@@ -10266,6 +11292,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10276,6 +11303,7 @@
     "Forces": "kbd",
     "Key": "D♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10286,6 +11314,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10296,6 +11325,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10306,6 +11336,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10316,6 +11347,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10326,6 +11358,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10336,6 +11369,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10346,6 +11380,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10356,6 +11391,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10366,6 +11402,7 @@
     "Forces": "kbd",
     "Key": "A♭major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10376,6 +11413,7 @@
     "Forces": "kbd",
     "Key": "G♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10386,6 +11424,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10396,6 +11435,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10406,6 +11446,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10416,6 +11457,7 @@
     "Forces": "kbd",
     "Key": "B♭minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10426,6 +11468,7 @@
     "Forces": "kbd",
     "Key": "B major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10436,6 +11479,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10446,6 +11490,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1715–25",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "rev. in BWV 1044"
   },
@@ -10456,6 +11501,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1709",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10466,6 +11512,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10476,6 +11523,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "prelude composed byCornelius Heinrich Dretzel; composer of fugue uncertain"
   },
@@ -10486,6 +11534,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Christian Kittel"
   },
@@ -10496,6 +11545,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1725–26?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10506,6 +11556,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1725–26?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10516,6 +11567,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10526,6 +11578,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 902/1a"
   },
@@ -10536,6 +11589,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of prelude from BWV 902"
   },
@@ -10546,6 +11600,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 903a"
   },
@@ -10556,6 +11611,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 903"
   },
@@ -10566,6 +11622,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10576,6 +11633,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10586,6 +11644,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "fugue incompete"
   },
@@ -10596,6 +11655,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried Kirchhoff"
   },
@@ -10606,6 +11666,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried Kirchhoff"
   },
@@ -10616,6 +11677,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1703",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10626,6 +11688,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1712",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10636,6 +11699,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10646,6 +11710,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 912a"
   },
@@ -10656,6 +11721,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "early version of the Adagio from BWV 912"
   },
@@ -10666,6 +11732,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 913a"
   },
@@ -10676,6 +11743,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 913"
   },
@@ -10686,6 +11754,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10696,6 +11765,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10706,6 +11776,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10716,6 +11787,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10726,6 +11798,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10736,6 +11809,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; byJohann Bernhard Bach"
   },
@@ -10746,6 +11820,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10756,6 +11831,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10766,6 +11842,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1710–14?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10776,6 +11853,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed by Wilhelm Heironymous Pachelbel; see also BWV 923a"
   },
@@ -10786,6 +11864,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 923; Bach's authorship uncertain"
   },
@@ -10796,6 +11875,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10806,6 +11886,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 924a"
   },
@@ -10816,6 +11897,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 924; Bach's authorship uncertain"
   },
@@ -10826,6 +11908,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -10836,6 +11919,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10846,6 +11930,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10856,6 +11941,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10866,6 +11952,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10876,6 +11963,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10886,6 +11974,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -10896,6 +11985,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete; Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -10906,6 +11996,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10916,6 +12007,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10926,6 +12018,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10936,6 +12029,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10946,6 +12040,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10956,6 +12051,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10966,6 +12062,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10976,6 +12073,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10986,6 +12084,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10996,6 +12095,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11006,6 +12106,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11016,6 +12117,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1717?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11026,6 +12128,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1703–07",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11036,6 +12139,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Fugue rev. in BWV 543"
   },
@@ -11046,6 +12150,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1695–1700?",
+    "City": "Ohrdruf",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain (possibly composed byChristoph Graupner"
   },
@@ -11056,6 +12161,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "on a theme byTomaso Albinoni"
   },
@@ -11066,6 +12172,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11076,6 +12183,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1727?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11086,6 +12194,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11096,6 +12205,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "on a theme byTomaso Albinoni"
   },
@@ -11106,6 +12216,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1712",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "on a theme byTomaso Albinoni; see also BWV 951a"
   },
@@ -11116,6 +12227,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1712",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 951"
   },
@@ -11126,6 +12238,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11136,6 +12249,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11146,6 +12260,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "on a theme byJohann Adam Reincken"
   },
@@ -11156,6 +12271,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "previously thought to have been arr. from a work byJohann Christoph Erselius; see also BWV 955a"
   },
@@ -11166,6 +12282,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "early variant of BWV 955"
   },
@@ -11176,6 +12293,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11186,6 +12304,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "previously believed to be a fugue hpd"
   },
@@ -11196,6 +12315,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11206,6 +12326,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11216,6 +12337,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "incomplete; Bach's authorship uncertain"
   },
@@ -11226,6 +12348,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1712?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11236,6 +12359,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1783",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Georg Albrechtsberger"
   },
@@ -11246,6 +12370,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11256,6 +12381,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "arr. of BWV 1003"
   },
@@ -11266,6 +12392,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "arr. of the Sonata No.1 fromHortus MusicusbyJohann Adam Reincken"
   },
@@ -11276,6 +12403,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "arr. of the Sonata No.3 fromHortus MusicusbyJohann Adam Reincken"
   },
@@ -11286,6 +12414,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "arr. of an unidentified work by an unknown composer"
   },
@@ -11296,6 +12425,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "arr. of the 1st movt. of BWV 1005"
   },
@@ -11306,6 +12436,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -11316,6 +12447,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.25/2)"
   },
@@ -11326,6 +12458,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.1 inClavier-ÜbungII"
   },
@@ -11336,6 +12469,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arrs. of works by other composers"
   },
@@ -11346,6 +12480,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Revised version, arr. of theViolin Concerto in D major, RV 230, byAntonio Vivaldi"
   },
@@ -11356,6 +12491,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1711",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Early version, arr. of theViolin Concerto in D major, RV 230, byAntonio Vivaldi"
   },
@@ -11366,6 +12502,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theViolin Concerto in G major, RV 299, byAntonio Vivaldi"
   },
@@ -11376,6 +12513,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theOboe Concerto in D minorbyAlessandro Marcello"
   },
@@ -11386,6 +12524,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in G minor, RV 316, byAntonio Vivaldi"
   },
@@ -11396,6 +12535,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theViolin Concerto in E major, RV 265, byAntonio Vivaldi"
   },
@@ -11406,6 +12546,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "source unidentified"
   },
@@ -11416,6 +12557,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theViolin Concerto in G major, RV 310, byAntonio Vivaldi"
   },
@@ -11426,6 +12568,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of a Violin Concerto in D minor byGiuseppe Torelli"
   },
@@ -11436,6 +12579,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in B♭minor, RV 381, byAntonio Vivaldi"
   },
@@ -11446,6 +12590,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in C minor, Op.1 No.2, byBenedetto Marcello"
   },
@@ -11456,6 +12601,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of No.1 of the 6 Violin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar"
   },
@@ -11466,6 +12612,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "source unidentified"
   },
@@ -11476,6 +12623,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of a lost concerto by Prince Johann Ernst of Saxe-Weimar"
   },
@@ -11486,6 +12634,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in G minor, TWV 51:g21, byGeorg Philipp Telemann"
   },
@@ -11496,6 +12645,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "source unidentified"
   },
@@ -11506,6 +12656,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of No.4 of the 6 Violin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar; see also BWV 595"
   },
@@ -11516,6 +12667,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1741–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "published inClavier-ÜbungIV"
   },
@@ -11526,6 +12678,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11536,6 +12689,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11546,6 +12700,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -11556,6 +12711,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11566,6 +12722,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1721?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11576,6 +12733,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–21",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11586,6 +12744,7 @@
     "Forces": "lute",
     "Key": "G minor",
     "Date": "1727–31?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1011"
   },
@@ -11596,6 +12755,7 @@
     "Forces": "lute/hpd",
     "Key": "E minor",
     "Date": "1712–17?",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11606,6 +12766,7 @@
     "Forces": "lute/hpd",
     "Key": "C minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11616,6 +12777,7 @@
     "Forces": "lute/kbd",
     "Key": "E♭major",
     "Date": "1740–45?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11626,6 +12788,7 @@
     "Forces": "lute",
     "Key": "C minor",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11636,6 +12799,7 @@
     "Forces": "lute",
     "Key": "G minor",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. of 2nd movt. from BWV 1001"
   },
@@ -11646,6 +12810,7 @@
     "Forces": "vn",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "(link to complete collections of all 6 sonatas and partitas)"
   },
@@ -11656,6 +12821,7 @@
     "Forces": "vn",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "partly rev. in BWV 539; 2nd movt. arr. for lute as BWV 1000"
   },
@@ -11666,6 +12832,7 @@
     "Forces": "vn",
     "Key": "B minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11676,6 +12843,7 @@
     "Forces": "vn",
     "Key": "A minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. for kbd as BWV 964"
   },
@@ -11686,6 +12854,7 @@
     "Forces": "vn",
     "Key": "D minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11696,6 +12865,7 @@
     "Forces": "vn",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "1st movt. arr. for kbd as BWV 968"
   },
@@ -11706,6 +12876,7 @@
     "Forces": "vn",
     "Key": "E major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. for lute as BWV 1006a; 1st movt. arr. for org orch as Sinfonia of BWV 29"
   },
@@ -11716,6 +12887,7 @@
     "Forces": "lute",
     "Key": "E major",
     "Date": "1736–37",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1006"
   },
@@ -11726,6 +12898,7 @@
     "Forces": "vc",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "(link to complete collections of all 6 suites)"
   },
@@ -11736,6 +12909,7 @@
     "Forces": "vc",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11746,6 +12920,7 @@
     "Forces": "vc",
     "Key": "D minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11756,6 +12931,7 @@
     "Forces": "vc",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11766,6 +12942,7 @@
     "Forces": "vc",
     "Key": "E♭major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11776,6 +12953,7 @@
     "Forces": "vc",
     "Key": "C minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. for lute as BWV 995"
   },
@@ -11786,6 +12964,7 @@
     "Forces": "vc",
     "Key": "D major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11796,6 +12975,7 @@
     "Forces": "fl",
     "Key": "A minor",
     "Date": "1722–23",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11806,6 +12986,7 @@
     "Forces": "vn kbd",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11816,6 +12997,7 @@
     "Forces": "vn kbd",
     "Key": "B minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11826,6 +13008,7 @@
     "Forces": "vn kbd",
     "Key": "A major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11836,6 +13019,7 @@
     "Forces": "vn kbd",
     "Key": "E major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11846,6 +13030,7 @@
     "Forces": "vn kbd",
     "Key": "C minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11856,6 +13041,7 @@
     "Forces": "vn kbd",
     "Key": "F minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "see also BWV 1018a"
   },
@@ -11866,6 +13052,7 @@
     "Forces": "vn kbd",
     "Key": "F minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "alternative version of BWV 1018, 3rd movt."
   },
@@ -11876,6 +13063,7 @@
     "Forces": "vn kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "see also BWV 1019a"
   },
@@ -11886,6 +13074,7 @@
     "Forces": "vn kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "alternative version of BWV 1019"
   },
@@ -11896,6 +13085,7 @@
     "Forces": "vn/fl kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.542.5)"
   },
@@ -11906,6 +13096,7 @@
     "Forces": "vn bc",
     "Key": "G major",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "shares the bc part with BWV 1022 and BWV 1038"
   },
@@ -11916,6 +13107,7 @@
     "Forces": "vn kbd",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1038; Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
   },
@@ -11926,6 +13118,7 @@
     "Forces": "vn bc",
     "Key": "E minor",
     "Date": "1714–17?",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11936,6 +13129,7 @@
     "Forces": "vn bc",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11946,6 +13140,7 @@
     "Forces": "vn kbd",
     "Key": "A major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. of the Lute Sonata in A major, SC 47, by Silvius Leopold Weiss"
   },
@@ -11956,6 +13151,7 @@
     "Forces": "vn bc",
     "Key": "G minor",
     "Date": "before 1712",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11966,6 +13162,7 @@
     "Forces": "viol hpd",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11976,6 +13173,7 @@
     "Forces": "viol hpd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1039; see also BWV 1027a"
   },
@@ -11986,6 +13184,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "arrs. of movts. 1, 2 and 4 from BWV 1027a; Bach's authorship uncertain"
   },
@@ -11996,6 +13195,7 @@
     "Forces": "viol hpd",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12006,6 +13206,7 @@
     "Forces": "viol hpd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12016,6 +13217,7 @@
     "Forces": "fl hpd",
     "Key": "B minor",
     "Date": "1736–37",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12026,6 +13228,7 @@
     "Forces": "ob hpd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12036,6 +13239,7 @@
     "Forces": "fl hpd",
     "Key": "E♭major",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12046,6 +13250,7 @@
     "Forces": "fl hpd",
     "Key": "A major",
     "Date": "1736?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12056,6 +13261,7 @@
     "Forces": "fl bc",
     "Key": "C major",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12066,6 +13272,7 @@
     "Forces": "fl bc",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12076,6 +13283,7 @@
     "Forces": "fl bc",
     "Key": "E major",
     "Date": "1741",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12086,6 +13294,7 @@
     "Forces": "2vn bc",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.145, H.569)"
   },
@@ -12096,6 +13305,7 @@
     "Forces": "2vn bc",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byJohann Gottlieb Goldberg"
   },
@@ -12106,6 +13316,7 @@
     "Forces": "fl vn bc",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "bc part virtually identical to that of BWV 1021; Bach's authorship for upper two voices uncertain; possibly composed byCarl Philipp Emanuel Bach(H.590.5); arr. for vn hpd as BWV 1022"
   },
@@ -12116,6 +13327,7 @@
     "Forces": "2fl bc",
     "Key": "G major",
     "Date": "1736–41?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. for viol hpd as BWV 1027"
   },
@@ -12126,6 +13338,7 @@
     "Forces": "ob vn bc",
     "Key": "F major",
     "Date": "1713–16?",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12136,6 +13349,7 @@
     "Forces": "vn str bc",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "arr. for hpd str bc as BWV 1058"
   },
@@ -12146,6 +13360,7 @@
     "Forces": "vn str bc",
     "Key": "E major",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "arr. for hpd str bc as BWV 1054"
   },
@@ -12156,6 +13371,7 @@
     "Forces": "2vn bc str",
     "Key": "D minor",
     "Date": "1718–20?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "arr. for hpd str bc as BWV 1062"
   },
@@ -12166,6 +13382,7 @@
     "Forces": "fl hpd vn str bc",
     "Key": "A minor",
     "Date": "1738–40?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "movts. based on BWV 894/1, 527/2, 894/3 respectively"
   },
@@ -12176,6 +13393,7 @@
     "Forces": "vn orch",
     "Key": "D major",
     "Date": "1743–46?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "from a lost cantata; Bach's authorship uncertain"
   },
@@ -12186,6 +13404,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "1721",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "2nd version of BWV 1046"
   },
@@ -12196,6 +13415,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "1st version of BWV 1046"
   },
@@ -12206,6 +13426,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12216,6 +13437,7 @@
     "Forces": "hpd str",
     "Key": "G major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "1st movt. arr. for orch as Sinfonia of BWV 174"
   },
@@ -12226,6 +13448,7 @@
     "Forces": "orch",
     "Key": "G major",
     "Date": "1719–20",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "arr. for 2rec hpd str bc as BWV 1057"
   },
@@ -12236,6 +13459,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1720–21",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "see also BWV 1050a"
   },
@@ -12246,6 +13470,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1719?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "early version of BWV 1050"
   },
@@ -12256,6 +13481,7 @@
     "Forces": "hpd str",
     "Key": "B♭major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12266,6 +13492,7 @@
     "Forces": "hpd str bc",
     "Key": "D minor",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost Violin Concerto (see BWV 1052R); partly re-used in BWV 146, BWV 188; see also BWV 1052a"
   },
@@ -12276,6 +13503,7 @@
     "Forces": "hpd str bc",
     "Key": "D minor",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "earlier version of BWV 1052; possibly an arr. by C. P. E. Bach"
   },
@@ -12286,6 +13514,7 @@
     "Forces": "vn str bc",
     "Key": "D minor",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 146, 188, 1052a and 1052"
   },
@@ -12296,6 +13525,7 @@
     "Forces": "hpd str bc",
     "Key": "E major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost Oboe Concerto (see BWV 1053R); partly re-used in BWV 49, BWV 169"
   },
@@ -12306,6 +13536,7 @@
     "Forces": "ob/oda str bc",
     "Key": "F major",
     "Date": "1730–38?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 49, 169 and 1053. Also has been reconstructed for Oboe d'amore."
   },
@@ -12316,6 +13547,7 @@
     "Forces": "hpd str bc",
     "Key": "D major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1042"
   },
@@ -12326,6 +13558,7 @@
     "Forces": "hpd str bc",
     "Key": "A major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost concerto for oboe d'amore (see BWV 1055R)"
   },
@@ -12336,6 +13569,7 @@
     "Forces": "oda str bc",
     "Key": "A major",
     "Date": "1730–38?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1055"
   },
@@ -12346,6 +13580,7 @@
     "Forces": "hpd str bc",
     "Key": "F minor",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost violin concerto; partly re-used in BWV 156"
   },
@@ -12356,6 +13591,7 @@
     "Forces": "vn str bc",
     "Key": "G minor",
     "Date": "1730–38?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1056"
   },
@@ -12366,6 +13602,7 @@
     "Forces": "2rec hpd str bc",
     "Key": "F major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1049"
   },
@@ -12376,6 +13613,7 @@
     "Forces": "hpd str bc",
     "Key": "G minor",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1041"
   },
@@ -12386,6 +13624,7 @@
     "Forces": "hpd ob str bc",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost oboe concerto (see BWV 1059R); incomplete; partly rev. as BWV 35"
   },
@@ -12396,6 +13635,7 @@
     "Forces": "ob str bc",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 35, 156, and 1059"
   },
@@ -12406,6 +13646,7 @@
     "Forces": "2hpd str bc",
     "Key": "C minor",
     "Date": "1730–45?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost concerto for oboe and violin (see BWV 1060R)"
   },
@@ -12416,6 +13657,7 @@
     "Forces": "ob vn str bc",
     "Key": "C minor",
     "Date": "1719?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1060"
   },
@@ -12426,6 +13668,7 @@
     "Forces": "2hpd str bc",
     "Key": "C major",
     "Date": "1733–34",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "2nd version of BWV 1061a"
   },
@@ -12436,6 +13679,7 @@
     "Forces": "2hpd",
     "Key": "C major",
     "Date": "1732–33",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "1st version of BWV 1061"
   },
@@ -12446,6 +13690,7 @@
     "Forces": "2hpd str bc",
     "Key": "C minor",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1043"
   },
@@ -12456,6 +13701,7 @@
     "Forces": "3hpd str bc",
     "Key": "D minor",
     "Date": "1735–45?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12466,6 +13712,7 @@
     "Forces": "3hpd str bc",
     "Key": "C major",
     "Date": "1735–45?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost concerto for 3vn (see BWV 1064R)"
   },
@@ -12476,6 +13723,7 @@
     "Forces": "3vn str bc",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1064"
   },
@@ -12486,6 +13734,7 @@
     "Forces": "4hpd str bc",
     "Key": "A minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of theConcerto for 4 Violins and Cello in B minor, RV 580, byAntonio Vivaldi"
   },
@@ -12496,6 +13745,7 @@
     "Forces": "orch",
     "Key": "C major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12506,6 +13756,7 @@
     "Forces": "orch",
     "Key": "B minor",
     "Date": "1738–39",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12516,6 +13767,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12526,6 +13778,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12536,6 +13789,7 @@
     "Forces": "orch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "Bach's authorship uncertain"
   },
@@ -12546,6 +13800,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "—",
     "Notes": "see BWV 1046a"
   },
@@ -12556,6 +13811,7 @@
     "Forces": "8vv",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12566,6 +13822,7 @@
     "Forces": "4open",
     "Key": "A minor",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12576,6 +13833,7 @@
     "Forces": "4open",
     "Key": "A minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12586,6 +13844,7 @@
     "Forces": "2open",
     "Key": "D major",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12596,6 +13855,7 @@
     "Forces": "4open",
     "Key": "G major",
     "Date": "1746",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12606,6 +13866,7 @@
     "Forces": "3open",
     "Key": "G major",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12616,6 +13877,7 @@
     "Forces": "7open",
     "Key": "F major",
     "Date": "1749",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12626,6 +13888,7 @@
     "Forces": "fl hpd 2vn",
     "Key": "",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12636,6 +13899,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -12646,6 +13910,7 @@
     "Forces": "ch bc",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "chorale for aMissa brevisbyGiovanni Battista Bassani"
   },
@@ -12656,6 +13921,7 @@
     "Forces": "ch str bc",
     "Key": "E minor",
     "Date": "1740–42",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "arr. of the 3rd movt. of the Magnificat in C major byAntonio Caldara"
   },
@@ -12666,6 +13932,7 @@
     "Forces": "2vv str bc",
     "Key": "",
     "Date": "1745–47",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "adaptation of theStabat MaterbyGiovanni Battista Pergolesi"
   },
@@ -12676,6 +13943,7 @@
     "Forces": "ch vn 2va bc",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -12686,6 +13954,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1715–18?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12696,6 +13965,7 @@
     "Forces": "2open",
     "Key": "D major",
     "Date": "1750?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12706,6 +13976,7 @@
     "Forces": "6open",
     "Key": "G major",
     "Date": "1747–48",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "based on the theme of BWV 988"
   },
@@ -12716,6 +13987,7 @@
     "Forces": "v 2bn/2vc bc",
     "Key": "G minor/ E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "intended for thePassions-PasticciobyKarl Heinrich Graun; Bach's authorship uncertain"
   },
@@ -12726,6 +13998,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -12736,6 +14009,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12746,6 +14020,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12756,6 +14031,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12766,6 +14042,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12776,6 +14053,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12786,6 +14064,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12796,6 +14075,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12806,6 +14086,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "also attributed toJohann Pachelbel"
   },
@@ -12816,6 +14097,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12826,6 +14108,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12836,6 +14119,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12846,6 +14130,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12856,6 +14141,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12866,6 +14152,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12876,6 +14163,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12886,6 +14174,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12896,6 +14185,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12906,6 +14196,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12916,6 +14207,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12926,6 +14218,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12936,6 +14229,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12946,6 +14240,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12956,6 +14251,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12966,6 +14262,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12976,6 +14273,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12986,6 +14284,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12996,6 +14295,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13006,6 +14306,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13016,6 +14317,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13026,6 +14328,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13036,6 +14339,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13046,6 +14350,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13056,6 +14361,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1706–10",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "formerly BWV Anh.205"
   },
@@ -13066,6 +14372,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13076,6 +14383,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13086,6 +14394,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13096,6 +14405,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13106,6 +14416,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13116,6 +14427,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13126,6 +14438,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -13136,6 +14449,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "formerly BWV Anh.71"
   },
@@ -13146,6 +14460,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Text",
     "Notes": "Regula Joh. Seb. Bachii"
   },
@@ -13156,6 +14471,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1742-43",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": "Canones aliquot per Josephum Zarlinum"
   },
@@ -13166,6 +14482,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1743-46",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": ""
   },
@@ -13176,6 +14493,7 @@
     "Forces": "—",
     "Key": "",
     "Date": "1743-46",
+    "City": "Leipzig",
     "Genre": "—",
     "Notes": ""
   },
@@ -13186,6 +14504,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1740-45",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": "Basso continuo rules (Generalbassregeln I)"
   },
@@ -13196,6 +14515,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1738?",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": "Basso continuo rules (Generalbassregeln II)"
   },
@@ -13206,6 +14526,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.199.Cantata for the Feast of the Annunciation; lost"
   },
@@ -13216,6 +14537,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1714-17",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.209."
   },
@@ -13226,6 +14548,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1709",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.192. 2nd Cantata for the inauguration of Mühlhausen town council; lost"
   },
@@ -13236,6 +14559,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "3rd Cantata for the inauguration of Mühlhausen town council; lost"
   },
@@ -13246,6 +14570,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.192. Cantata for the inauguration of Leipzig town council; 1st version of BWV 1139a; music lost"
   },
@@ -13256,6 +14581,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.4a. Cantata for the 3rd day of the 200th anniversary of the Augsburg Confession; 2nd version of BWV 1139; music lost"
   },
@@ -13266,6 +14592,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.3. Cantata for the inauguration of Leipzig town council; music lost"
   },
@@ -13276,6 +14603,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.193. cantata for the inauguration of Leipzig town council; last chorus based on BWV 208, otherwise lost"
   },
@@ -13286,6 +14614,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "cantata for the memorial service for Prince Johann Ernst of Saxe-Weimar, otherwise lost"
   },
@@ -13296,6 +14625,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 244a. Partly based on BWV 198, BWV 247, BWV 244b; lost"
   },
@@ -13306,6 +14636,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.14. Wedding cantata for Christoph Friedrich Lösner and Johanna Elisabetha Scherling; music lost"
   },
@@ -13316,6 +14647,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.211. Cantata for the wedding of the lawyer and university professor Johann Friedrich Höckner with Jacobina Agnetha Bartholomäus, otherwise music lost"
   },
@@ -13326,6 +14658,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.212. Cantata for the wedding of the merchant Christoph Georg Winckler with Caroline Wilhelmine Jöcher, otherwise music lost"
   },
@@ -13336,6 +14669,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.5. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13346,6 +14680,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "1724?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.15. Cantata for a degree ceremony at Leipzig University; fragment only"
   },
@@ -13356,6 +14691,7 @@
     "Forces": "5vv orch",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "arrangement of the motet \"Tristis est anima mea\" probably byJohann Kuhnau"
   },
@@ -13366,6 +14702,7 @@
     "Forces": "bass orch",
     "Key": "",
     "Date": "1721-22",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.197. Cantata as a tribute music in honor of the princely house of Anhalt-Köthen or was for New Year's Day; lost"
   },
@@ -13376,6 +14713,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1719",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.6. Cantata for New Year's Day; music lost"
   },
@@ -13386,6 +14724,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.8. Cantata for New Year's Day; lost; possibly the same as BWV 184a"
   },
@@ -13396,6 +14735,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.7. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13406,6 +14746,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.194. Cantata for the birthday of Johann August of Anhalt-Zerbst; lost"
   },
@@ -13416,6 +14757,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.20. Cantata (ode) for the birthday of Duke Friedrich II of Saxe-Gotha; music lost"
   },
@@ -13426,6 +14768,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.9. Cantata for birthday of King August III; music lost"
   },
@@ -13436,6 +14779,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.11. Cantata for the nameday of King August II of Poland; music lost"
   },
@@ -13446,6 +14790,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.12. Cantata for the nameday of King August III of Poland; based on BWV Anh.18; music lost"
   },
@@ -13456,6 +14801,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the birthday of King August III of Poland; libretto and music lost"
   },
@@ -13466,6 +14812,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.10. Cantata for the birthday of Joachim Friedrich Reichsgraf von Flemming; music lost"
   },
@@ -13476,6 +14823,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.13. Cantata for the wedding of Prince Carl IV and Princess Maria Amalia; music lost"
   },
@@ -13486,6 +14834,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.18. Cantata for occasion of the rededication of the rebuilt St. Thomas School; music lost; rev. as BWV Anh.12"
   },
@@ -13496,6 +14845,7 @@
     "Forces": "4vv ch orch?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.196. Cantata on the occasion of the wedding of Peter Hohman the Younger; music lost"
   },
@@ -13506,6 +14856,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1731-32",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "music lost"
   },
@@ -13516,6 +14867,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "1713?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.159. Attributed toJohann Christoph Bach"
   },
@@ -13526,6 +14878,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1713?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -13536,6 +14889,7 @@
     "Forces": "5vv orch",
     "Key": "",
     "Date": "1735-50",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "is based onKarl Heinrich Graun's Passion cantata \"Ein Lämmlein geht und tragen die Schuld\" (so-called \"Kleine Passion\" (GraunWV B:VII:4), Braunschweig before 1735) withGeorg Philipp Telemann's opening chorus, \"Wer ist der, so von Edom kömmt\" TVWV 1:1585 (from the Palmarum cantata of the French vintage), and the following chorale movement for \"Christus, der uns selig macht\" (from D to E transposed final chorale of the same cantata); the following movements (3rd–18th) are all by Graun."
   },
@@ -13546,6 +14900,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.213. Arrangement of a concerto byGeorg Philipp Telemann"
   },
@@ -13556,6 +14911,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.200. Incomplete"
   },
@@ -13566,6 +14922,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1714–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.55. Bach's authorship uncertain"
   },
@@ -13576,6 +14933,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13586,6 +14944,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13596,6 +14955,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13606,6 +14966,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13616,6 +14977,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13626,6 +14988,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.77. Bach's authorship uncertain"
   },
@@ -13636,6 +14999,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -13646,6 +15010,7 @@
     "Forces": "vv 2fl str bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:617)"
   },
@@ -13656,6 +15021,7 @@
     "Forces": "4vv ch str bc",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the 19th Sunday after Trinity; fragment only"
   },
@@ -13666,6 +15032,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1140. Cantata for the inauguration of Leipzig town council; music lost"
   },
@@ -13676,6 +15043,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1139. Cantata for the inauguration of Leipzig town council; 1st version of BWV Anh.4a; music lost"
   },
@@ -13686,6 +15054,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1139a. Cantata for the 3rd day of the 200th anniversary of the Augsburg Confession; 2nd version of BWV Anh.4; music lost"
   },
@@ -13696,6 +15065,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1147. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13706,6 +15076,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1719",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1151. Cantata for New Year's Day; music lost"
   },
@@ -13716,6 +15087,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1153. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13726,6 +15098,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1152. Cantata for New Year's Day; lost; possibly the same as BWV 184a"
   },
@@ -13736,6 +15109,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1156. Cantata for birthday of King August III; music lost"
   },
@@ -13746,6 +15120,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1160. Cantata for the birthday of Joachim Friedrich Reichsgraf von Flemming; music lost"
   },
@@ -13756,6 +15131,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1157. Cantata for the nameday of King August II of Poland; music lost"
   },
@@ -13766,6 +15142,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1158. Cantata for the nameday of King August III of Poland; based on BWV Anh.18; music lost"
   },
@@ -13776,6 +15153,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1161. Cantata for the wedding of Prince Carl IV and Princess Maria Amalia; music lost"
   },
@@ -13786,6 +15164,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1144. Wedding cantata for Christoph Friedrich Lösner and Johanna Elisabetha Scherling; music lost"
   },
@@ -13796,6 +15175,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "1724?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1148. Cantata for a degree ceremony at Leipzig University; fragment only"
   },
@@ -13806,6 +15186,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "funeral cantata; music lost"
   },
@@ -13816,6 +15197,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "funeral cantata; fragments only"
   },
@@ -13826,6 +15208,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1162. Cantata for occasion of the rededication of the rebuilt St. Thomas School; music lost; rev. as BWV Anh.12"
   },
@@ -13836,6 +15219,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the Thomasschule in Leipzig; music lost"
   },
@@ -13846,6 +15230,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1155. Cantata (ode) for the birthday of Duke Friedrich II of Saxe-Gotha; music lost"
   },
@@ -13856,6 +15241,7 @@
     "Forces": "v fl str bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byMelchior Hoffmann"
   },
@@ -13866,6 +15252,7 @@
     "Forces": "ob vb orch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "lost, only the theme remains"
   },
@@ -13876,6 +15263,7 @@
     "Forces": "str bc",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "bc part only; spurious; composed byTomaso Albinoni"
   },
@@ -13886,6 +15274,7 @@
     "Forces": "ch str bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christoph Pez"
   },
@@ -13896,6 +15285,7 @@
     "Forces": "ch orch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13906,6 +15296,7 @@
     "Forces": "ch orch",
     "Key": "C minor",
     "Date": "1727–32",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "spurious; composed byFrancesco Durante, butChriste eleisonadapted by Bach as BWV 242"
   },
@@ -13916,6 +15307,7 @@
     "Forces": "ch orch",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig Krebs)"
   },
@@ -13926,6 +15318,7 @@
     "Forces": "ch orch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13936,6 +15329,7 @@
     "Forces": "?",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "bass part only; Bach's authorship uncertain"
   },
@@ -13946,6 +15340,7 @@
     "Forces": "2ch orch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain; possibly composed byAntonio Lotti"
   },
@@ -13956,6 +15351,7 @@
     "Forces": "ch 2tpt",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13966,6 +15362,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13976,6 +15373,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13986,6 +15384,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13996,6 +15395,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14006,6 +15406,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14016,6 +15417,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14026,6 +15428,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14036,6 +15439,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14046,6 +15450,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14056,6 +15461,7 @@
     "Forces": "kbd (or voice, keyboard)",
     "Key": "",
     "Date": "1734?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14066,6 +15472,7 @@
     "Forces": "kbd (or voice, keyboard)",
     "Key": "",
     "Date": "1734?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14076,6 +15483,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14086,6 +15494,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.233, H.776)"
   },
@@ -14096,6 +15505,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Peter KellnerorJohann Christoph Kellner"
   },
@@ -14106,6 +15516,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJustin Heinrich Knecht"
   },
@@ -14116,6 +15527,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Tobias Krebs"
   },
@@ -14126,6 +15538,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Peter Kellner"
   },
@@ -14136,6 +15549,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14146,6 +15560,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Gottfried Walther"
   },
@@ -14156,6 +15571,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14166,6 +15582,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14176,6 +15593,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14186,6 +15604,7 @@
     "Forces": "v bells str bc",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain; possibly composed byMelchior Hoffmann"
   },
@@ -14196,6 +15615,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14206,6 +15626,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1714–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see BWV 1170. Bach's authorship uncertain"
   },
@@ -14216,6 +15637,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Philipp Telemann"
   },
@@ -14226,6 +15648,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed by Johann Caspar Vogler"
   },
@@ -14236,6 +15659,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14246,6 +15670,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14256,6 +15681,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -14266,6 +15692,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Pachelbel"
   },
@@ -14276,6 +15703,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14286,6 +15714,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14296,6 +15725,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14306,6 +15736,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14316,6 +15747,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14326,6 +15758,7 @@
     "Forces": "tpt org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14336,6 +15769,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14346,6 +15780,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14356,6 +15791,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14366,6 +15802,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14376,6 +15813,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "see BWV 1128"
   },
@@ -14386,6 +15824,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14396,6 +15835,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
   },
@@ -14406,6 +15846,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried August Homilius; see also BWV 759"
   },
@@ -14416,6 +15857,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14426,6 +15868,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14436,6 +15879,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see BWV 1176. Bach's authorship uncertain"
   },
@@ -14446,6 +15890,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14456,6 +15901,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14466,6 +15912,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14476,6 +15923,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "incomplete; Bach's authorship uncertain"
   },
@@ -14486,6 +15934,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Bernhard Bach"
   },
@@ -14496,6 +15945,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Bernhard Bach"
   },
@@ -14506,6 +15956,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Bernhard Bach"
   },
@@ -14516,6 +15967,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14526,6 +15978,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14536,6 +15989,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14546,6 +16000,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Christoph Kellner"
   },
@@ -14556,6 +16011,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14566,6 +16022,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger; formerly attributed toCarl Philipp Emanuel Bachas H.388"
   },
@@ -14576,6 +16033,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14586,6 +16044,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14596,6 +16055,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14606,6 +16066,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger"
   },
@@ -14616,6 +16077,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14626,6 +16088,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14636,6 +16099,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -14646,6 +16110,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
   },
@@ -14656,6 +16121,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
   },
@@ -14666,6 +16132,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
   },
@@ -14676,6 +16143,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14686,6 +16154,7 @@
     "Forces": "kbd",
     "Key": "G♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14696,6 +16165,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14706,6 +16176,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14716,6 +16187,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14726,6 +16198,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14736,6 +16209,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Andreas Sorge"
   },
@@ -14746,6 +16220,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Andreas SorgeorCarl Philipp Emanuel Bach"
   },
@@ -14756,6 +16231,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14766,6 +16242,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; probably composed byGeorg Andreas Sorge"
   },
@@ -14776,6 +16253,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14786,6 +16264,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger"
   },
@@ -14796,6 +16275,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "20 doubtful or spurious piees"
   },
@@ -14806,6 +16286,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14816,6 +16297,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristian Pezold"
   },
@@ -14826,6 +16308,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristian Pezold"
   },
@@ -14836,6 +16319,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14846,6 +16330,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; see also BWV Anh.117b; Bach's authorship uncertain"
   },
@@ -14856,6 +16341,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternate version of BWV Anh.117a; Bach's authorship uncertain"
   },
@@ -14866,6 +16352,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14876,6 +16363,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
   },
@@ -14886,6 +16374,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14896,6 +16385,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14906,6 +16396,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/1)"
   },
@@ -14916,6 +16407,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/2)"
   },
@@ -14926,6 +16418,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/3)"
   },
@@ -14936,6 +16429,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/4)"
   },
@@ -14946,6 +16440,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14956,6 +16451,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "spurious"
   },
@@ -14966,6 +16462,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14976,6 +16473,7 @@
     "Forces": "hpd",
     "Key": "E♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.65/7, H.16)"
   },
@@ -14986,6 +16484,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Adolph Hasse"
   },
@@ -14996,6 +16495,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Christian Bach(W.A22); incomplete"
   },
@@ -15006,6 +16506,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15016,6 +16517,7 @@
     "Forces": "morg",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.207)"
   },
@@ -15026,6 +16528,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15036,6 +16539,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15046,6 +16550,7 @@
     "Forces": "vn bc",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15056,6 +16561,7 @@
     "Forces": "vn kbd",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15066,6 +16572,7 @@
     "Forces": "str bc kbd",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15076,6 +16583,7 @@
     "Forces": "ch str bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:732)"
   },
@@ -15086,6 +16594,7 @@
     "Forces": "ch orch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:836)"
   },
@@ -15096,6 +16605,7 @@
     "Forces": "v fl str bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christian Bach(part of the operaOrione, ossia Diana vendicata, W.G4)"
   },
@@ -15106,6 +16616,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "1713?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "see BWV 1165. Formerly attributed toJohann Christoph Bach"
   },
@@ -15116,6 +16627,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 8:10)"
   },
@@ -15126,6 +16638,7 @@
     "Forces": "2ch (strings, continuo?)",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byKarl Heinrich Graun(GraunWV 10)"
   },
@@ -15136,6 +16649,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed by Georg Gottfried Wagner"
   },
@@ -15146,6 +16660,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christoph Bach"
   },
@@ -15156,6 +16671,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christoph Altnikol"
   },
@@ -15166,6 +16682,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ernst Bach"
   },
@@ -15176,6 +16693,7 @@
     "Forces": "ch str bc",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig Bach"
   },
@@ -15186,6 +16704,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig BachorAntonio Lotti"
   },
@@ -15196,6 +16715,7 @@
     "Forces": "4vv str",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.100)"
   },
@@ -15206,6 +16726,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "music lost; probably never composed"
   },
@@ -15216,6 +16737,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Rosenmüller"
   },
@@ -15226,6 +16748,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Pachelbel"
   },
@@ -15236,6 +16759,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -15246,6 +16770,7 @@
     "Forces": "vn bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(Nos.2, 5, 6, 7 from Op.10)"
   },
@@ -15256,6 +16781,7 @@
     "Forces": "vn bc",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.2 from Op.10)"
   },
@@ -15266,6 +16792,7 @@
     "Forces": "vn bc",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.5 from Op.10)"
   },
@@ -15276,6 +16803,7 @@
     "Forces": "vn bc",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.6 from Op.10)"
   },
@@ -15286,6 +16814,7 @@
     "Forces": "vn bc",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.7 from Op.10)"
   },
@@ -15296,6 +16825,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Christoph Bach"
   },
@@ -15306,6 +16836,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composer uncertain"
   },
@@ -15316,6 +16847,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann David Heinichen"
   },
@@ -15326,6 +16858,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Peter Kellner"
   },
@@ -15336,6 +16869,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -15346,6 +16880,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristian Friedrich Witt"
   },
@@ -15356,6 +16891,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "inNotebook II for Anna Magdalena Bach; spurious; composed byFrançois Couperin"
   },
@@ -15366,6 +16902,7 @@
     "Forces": "vn bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarlo Zuccari(Op.1 No.10)"
   },
@@ -15376,6 +16913,7 @@
     "Forces": "2vn bc",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.585)"
   },
@@ -15386,6 +16924,7 @@
     "Forces": "2vn bc",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.154, H.576)"
   },
@@ -15396,6 +16935,7 @@
     "Forces": "fl bn vn",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.159, H.587)"
   },
@@ -15406,6 +16946,7 @@
     "Forces": "2hpd",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.10)"
   },
@@ -15416,6 +16957,7 @@
     "Forces": "hpd str bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.1, H.403)"
   },
@@ -15426,6 +16968,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for Easter Monday; fragment only"
   },
@@ -15436,6 +16979,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -15446,6 +16990,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1709",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "see BWV 1137. cantata for the inauguration of Mühlhausen town council; lost"
   },
@@ -15456,6 +17001,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1141. Cantata for the inauguration of Leipzig town council; last chorus based on BWV 208, otherwise lost"
   },
@@ -15466,6 +17012,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1154. Cantata for the birthday of Johann August of Anhalt-Zerbst; lost"
   },
@@ -15476,6 +17023,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for Johann Florens Rivinus; lost"
   },
@@ -15486,6 +17034,7 @@
     "Forces": "4vv ch orch?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1163. Cantata on the occasion of the wedding of Peter Hohman the Younger; lost"
   },
@@ -15496,6 +17045,7 @@
     "Forces": "bass orch",
     "Key": "",
     "Date": "1721-22",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1150. Cantata as a tribute music in honor of the princely house of Anhalt-Köthen or was for New Year's Day; lost"
   },
@@ -15506,6 +17056,7 @@
     "Forces": "ch orch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "cantata for the Feast of St. Michael; fragment only"
   },
@@ -15516,6 +17067,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1135. cantata for the Feast of the Annunciation; lost"
   },
@@ -15526,6 +17078,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see BWV 1169. Incomplete"
   },
@@ -15536,6 +17089,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15546,6 +17100,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15556,6 +17111,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15566,6 +17122,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15576,6 +17133,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15586,6 +17144,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1706–10",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "see BWV 1121."
   },
@@ -15596,6 +17155,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15606,6 +17166,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Peter Kellner"
   },
@@ -15616,6 +17177,7 @@
     "Forces": "kbd",
     "Key": "E♭minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Johann Ernst Eberlin"
   },
@@ -15626,6 +17188,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1714-17",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "see BWV 1136."
   },
@@ -15636,6 +17199,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "probably never composed. Music for the farewell party for the Thomasschule rector Johann Matthias Gesner, otherwise music lost."
   },
@@ -15646,6 +17210,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1145. Cantata for the wedding of the lawyer and university professor Johann Friedrich Höckner with Jacobina Agnetha Bartholomäus, otherwise music lost"
   },
@@ -15656,6 +17221,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1146. Cantata for the wedding of the merchant Christoph Georg Winckler with Caroline Wilhelmine Jöcher, otherwise music lost"
   },
@@ -15666,6 +17232,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "see BWV 1168. Arrangement of a concerto byGeorg Philipp Telemann"
   }

--- a/index.html
+++ b/index.html
@@ -133,7 +133,8 @@
             table.classList.toggle('collapsed');
           });
           const thead = document.createElement('thead');
-          thead.innerHTML = `<tr><th>BWV</th><th>BC</th><th>Tytuł</th><th>Tonacja</th><th>Data</th><th>Gatunek</th><th>Obsada</th><th>Uwagi</th><th>Tekst</th><th>Video</th></tr>`;
+          // Kolumna "Miasto" może pozostać pusta, jeśli brak danych o miejscu powstania
+          thead.innerHTML = `<tr><th>BWV</th><th>BC</th><th>Tytuł</th><th>Tonacja</th><th>Data</th><th>Miasto</th><th>Gatunek</th><th>Obsada</th><th>Uwagi</th><th>Tekst</th><th>Video</th></tr>`;
           table.appendChild(thead);
           const tbody = document.createElement('tbody');
           table.appendChild(tbody);
@@ -163,6 +164,7 @@
               <td>${row.Title}</td>
               <td>${row.Key}</td>
               <td>${row.Date}</td>
+              <td>${row.City || ''}</td>
               <td>${row.Genre}</td>
               <td>${row.Forces}</td>
               <td>${row.Notes}</td>

--- a/works.json
+++ b/works.json
@@ -6,6 +6,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -16,6 +17,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -26,6 +28,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -36,6 +39,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1707–08?, rev. 1724–25",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -46,6 +50,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -56,6 +61,7 @@
     "Forces": "4vv ch orch",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.III adapted in BWV 649"
   },
@@ -66,6 +72,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -76,6 +83,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1724, rev. 1744–47",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -86,6 +94,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -96,6 +105,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.V adapted in BWV 648"
   },
@@ -106,6 +116,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233"
   },
@@ -116,6 +127,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -126,6 +138,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -136,6 +149,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -146,6 +160,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig Bach"
   },
@@ -156,6 +171,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -166,6 +182,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 236"
   },
@@ -176,6 +193,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1713–14, rev. 1724",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233"
   },
@@ -186,6 +204,7 @@
     "Forces": "3vv ch orch",
     "Key": "C major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -196,6 +215,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -206,6 +226,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -216,6 +237,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -226,6 +248,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1723, rev. 1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -236,6 +259,7 @@
     "Forces": "4vv ch orch",
     "Key": "F major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -246,6 +270,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -256,6 +281,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -266,6 +292,7 @@
     "Forces": "4vv ch orch",
     "Key": "C minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -276,6 +303,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "theme used in BWV 231"
   },
@@ -286,6 +314,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Sinfonia (No. 1) based on the Prelude (No. 1) of the Violin Partita No. 3 BWV 1006."
   },
@@ -296,6 +325,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -306,6 +336,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1737",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "dramma per musica"
   },
@@ -316,6 +347,7 @@
     "Forces": "3vv ch orch",
     "Key": "C major",
     "Date": "1715, rev. 1724",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -326,6 +358,7 @@
     "Forces": "2vv ch orch",
     "Key": "E minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -336,6 +369,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -346,6 +380,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1746–47",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "adapted from BWV 34a"
   },
@@ -356,6 +391,7 @@
     "Forces": "4vv ch (orch?)",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost; rev. as BWV 34"
   },
@@ -366,6 +402,7 @@
     "Forces": "v orch",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on a lost oboe concerto (see BWV 1059R)"
   },
@@ -376,6 +413,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1725–30?, rev. 1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 36c"
   },
@@ -386,6 +424,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV.36c; lost"
   },
@@ -396,6 +435,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -406,6 +446,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "rev. as BWV.36"
   },
@@ -416,6 +457,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -426,6 +468,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -436,6 +479,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -446,6 +490,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233"
   },
@@ -456,6 +501,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -466,6 +512,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -476,6 +523,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -486,6 +534,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -496,6 +545,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -506,6 +556,7 @@
     "Forces": "3vv ch orch",
     "Key": "D minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -516,6 +567,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -526,6 +578,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -536,6 +589,7 @@
     "Forces": "2vv orch",
     "Key": "E major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "sinfonia based on a lost oboe concerto (see BWV 1053R)"
   },
@@ -546,6 +600,7 @@
     "Forces": "2ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -556,6 +611,7 @@
     "Forces": "v tpt str bc",
     "Key": "C major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -566,6 +622,7 @@
     "Forces": "v ch orch",
     "Key": "F major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -576,6 +633,7 @@
     "Forces": "v perc org str",
     "Key": "E major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byMelchior Hoffmann"
   },
@@ -586,6 +644,7 @@
     "Forces": "v str bc",
     "Key": "E♭major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "partly rev. in BWV 247"
   },
@@ -596,6 +655,7 @@
     "Forces": "v ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -606,6 +666,7 @@
     "Forces": "v ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -616,6 +677,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -626,6 +688,7 @@
     "Forces": "2vv orch",
     "Key": "C major",
     "Date": "1727, rev. 1733–34?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -636,6 +699,7 @@
     "Forces": "2vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 74"
   },
@@ -646,6 +710,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -656,6 +721,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -666,6 +732,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -676,6 +743,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1714–15, rev. 1729?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -686,6 +754,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -696,6 +765,7 @@
     "Forces": "2vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -706,6 +776,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 66a"
   },
@@ -716,6 +787,7 @@
     "Forces": "2vv ch orch",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "lost; rev. as BWV 66"
   },
@@ -726,6 +798,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234"
   },
@@ -736,6 +809,7 @@
     "Forces": "2vv ch orch",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -746,6 +820,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1742–48",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 69a"
   },
@@ -756,6 +831,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 69"
   },
@@ -766,6 +842,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 70a"
   },
@@ -776,6 +853,7 @@
     "Forces": "",
     "Key": "C major",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "text not lost, but music survives in a few individual parts; rev. as BWV 70"
   },
@@ -786,6 +864,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -796,6 +875,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 235"
   },
@@ -806,6 +886,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1724, rev. 1730–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -816,6 +897,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 59"
   },
@@ -826,6 +908,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -836,6 +919,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -846,6 +930,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version; partly re-used in BWV 528"
   },
@@ -856,6 +941,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -866,6 +952,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -876,6 +963,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234, BWV 236"
   },
@@ -886,6 +974,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1727–31, rev. 1744–47?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 80a, 80b; 1st version"
   },
@@ -896,6 +985,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "lost; rev. in BWV 80"
   },
@@ -906,6 +996,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "fragment only; rev. in BWV 80"
   },
@@ -916,6 +1007,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -926,6 +1018,7 @@
     "Forces": "v ob str bc",
     "Key": "C minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -936,6 +1029,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -946,6 +1040,7 @@
     "Forces": "v ch orch",
     "Key": "E minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -956,6 +1051,7 @@
     "Forces": "4vv ch orch",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -966,6 +1062,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -976,6 +1073,7 @@
     "Forces": "3vv ch orch",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -986,6 +1084,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -996,6 +1095,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1006,6 +1106,7 @@
     "Forces": "3vv ch orch",
     "Key": "D minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1016,6 +1117,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1026,6 +1128,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1036,6 +1139,7 @@
     "Forces": "4vv ch 2ob str bc",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.IV adapted in BWV 647"
   },
@@ -1046,6 +1150,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1056,6 +1161,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1066,6 +1172,7 @@
     "Forces": "4vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1076,6 +1183,7 @@
     "Forces": "4vv ch orch",
     "Key": "B♭major",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1086,6 +1194,7 @@
     "Forces": "4vv ch orch",
     "Key": "B♭major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1096,6 +1205,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1106,6 +1216,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1116,6 +1227,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1126,6 +1238,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 233, BWV 235"
   },
@@ -1136,6 +1249,7 @@
     "Forces": "2vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1146,6 +1260,7 @@
     "Forces": "2vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1156,6 +1271,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1166,6 +1282,7 @@
     "Forces": "2vv ch orch",
     "Key": "E♭major",
     "Date": "1707–08?",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1176,6 +1293,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1186,6 +1304,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1196,6 +1315,7 @@
     "Forces": "2vv ch orch",
     "Key": "D minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1206,6 +1326,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1216,6 +1337,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1226,6 +1348,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1236,6 +1359,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1246,6 +1370,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1256,6 +1381,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1266,6 +1392,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1276,6 +1403,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1728–31?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1286,6 +1414,7 @@
     "Forces": "ch orch",
     "Key": "B♭major",
     "Date": "1736–37, rev. 1746–47?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1296,6 +1425,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1306,6 +1436,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1728–29?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 120a,  120b"
   },
@@ -1316,6 +1447,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1729?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 120; partly lost"
   },
@@ -1326,6 +1458,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -1336,6 +1469,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1346,6 +1480,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1356,6 +1491,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1366,6 +1502,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1376,6 +1513,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1386,6 +1524,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1396,6 +1535,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1406,6 +1546,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1416,6 +1557,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1426,6 +1568,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1436,6 +1579,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1707–08",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1446,6 +1590,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; arr. from the finale of BWV 131"
   },
@@ -1456,6 +1601,7 @@
     "Forces": "4vv ch orch",
     "Key": "A major",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1466,6 +1612,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1476,6 +1623,7 @@
     "Forces": "2vv ch orch",
     "Key": "B♭major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 134a"
   },
@@ -1486,6 +1634,7 @@
     "Forces": "2vv ch orch",
     "Key": "B♭major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 134"
   },
@@ -1496,6 +1645,7 @@
     "Forces": "3vv ch orch",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1506,6 +1656,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234"
   },
@@ -1516,6 +1667,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.II adapted in BWV 650"
   },
@@ -1526,6 +1678,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 236"
   },
@@ -1536,6 +1689,7 @@
     "Forces": "4vv ch orch",
     "Key": "E major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1546,6 +1700,7 @@
     "Forces": "3vv ch orch",
     "Key": "E♭major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "movt.IV adapted in BWV 645"
   },
@@ -1556,6 +1711,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann"
   },
@@ -1566,6 +1722,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; probably compoed byJohann Kuhnau"
   },
@@ -1576,6 +1733,7 @@
     "Forces": "3vv ch orch",
     "Key": "B♭major",
     "Date": "1708–14",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -1586,6 +1744,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1596,6 +1755,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1606,6 +1766,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on a lost violin concerto (see BWV 1052R)"
   },
@@ -1616,6 +1777,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 147a"
   },
@@ -1626,6 +1788,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "rext is not lost, but only the first four sheets of the musical score survives; rev. as BWV 147"
   },
@@ -1636,6 +1799,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1646,6 +1810,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1656,6 +1821,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1706",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1666,6 +1832,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1726, rev. 1727?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1676,6 +1843,7 @@
     "Forces": "2vv orch",
     "Key": "",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1686,6 +1854,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1696,6 +1865,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1706,6 +1876,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1716,6 +1887,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "sinfonia based on BWV 1056"
   },
@@ -1726,6 +1898,7 @@
     "Forces": "2vv ch orch",
     "Key": "B minor",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 157a"
   },
@@ -1736,6 +1909,7 @@
     "Forces": "2vv ch orch",
     "Key": "B minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 157"
   },
@@ -1746,6 +1920,7 @@
     "Forces": "v ch ob vn bc",
     "Key": "D major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 158a"
   },
@@ -1756,6 +1931,7 @@
     "Forces": "v ch ob vn bc",
     "Key": "D major",
     "Date": "1732–35",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; rev. as BWV 158"
   },
@@ -1766,6 +1942,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1776,6 +1953,7 @@
     "Forces": "v bn vn bc",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:877)"
   },
@@ -1786,6 +1964,7 @@
     "Forces": "2vv ch orch",
     "Key": "C major",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1796,6 +1975,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -1806,6 +1986,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1816,6 +1997,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1826,6 +2008,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1836,6 +2019,7 @@
     "Forces": "3vv ch orch",
     "Key": "B♭major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -1846,6 +2030,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1856,6 +2041,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1866,6 +2052,7 @@
     "Forces": "v ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on a lost oboe concerto (see BWV 1053R)"
   },
@@ -1876,6 +2063,7 @@
     "Forces": "v orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1886,6 +2074,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1728?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1896,6 +2085,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -1906,6 +2096,7 @@
     "Forces": "4vv ch orch",
     "Key": "C major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version"
   },
@@ -1916,6 +2107,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 173a"
   },
@@ -1926,6 +2118,7 @@
     "Forces": "2vv orch",
     "Key": "D major",
     "Date": "1717–22?",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "rev. as BWV 173"
   },
@@ -1936,6 +2129,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Sinfonia (No. 1) based on the 1st movt. of the Brandenburg Concerto No.3 BWV 1048."
   },
@@ -1946,6 +2140,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1956,6 +2151,7 @@
     "Forces": "3vv ch orch",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1966,6 +2162,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1976,6 +2173,7 @@
     "Forces": "3vv ch orch",
     "Key": "A minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -1986,6 +2184,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 234, BWV 236"
   },
@@ -1996,6 +2195,7 @@
     "Forces": "4vv ch orch",
     "Key": "F major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2006,6 +2206,7 @@
     "Forces": "4vv ch orch",
     "Key": "E minor",
     "Date": "1724, rev. 1743–46",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2016,6 +2217,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -2026,6 +2228,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version"
   },
@@ -2036,6 +2239,7 @@
     "Forces": "4vv ch orch",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2046,6 +2250,7 @@
     "Forces": "3vv ch orch",
     "Key": "G major",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 184a"
   },
@@ -2056,6 +2261,7 @@
     "Forces": "",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "lost; possibly the same as BWV Anh.8; rev. as BWV 184"
   },
@@ -2066,6 +2272,7 @@
     "Forces": "4vv ch orch",
     "Key": "F♯minor",
     "Date": "1715",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2076,6 +2283,7 @@
     "Forces": "4vv ch orch",
     "Key": "G minor",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 186a"
   },
@@ -2086,6 +2294,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "text not lost, but music survives in a few individual parts; rev. as BWV 186"
   },
@@ -2096,6 +2305,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "parts re-used in BWV 235"
   },
@@ -2106,6 +2316,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "sinfonia based on a lost violin concerto (see BWV 1052R)"
   },
@@ -2116,6 +2327,7 @@
     "Forces": "v orch",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byMelchior Hoffmann"
   },
@@ -2126,6 +2338,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost; rev. as BWV 190a"
   },
@@ -2136,6 +2349,7 @@
     "Forces": "",
     "Key": "D major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2146,6 +2360,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1741–45",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 232/1"
   },
@@ -2156,6 +2371,7 @@
     "Forces": "2vv ch orch",
     "Key": "G major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost"
   },
@@ -2166,6 +2382,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2176,6 +2393,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2186,6 +2404,7 @@
     "Forces": "3vv ch orch",
     "Key": "B♭major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 194a"
   },
@@ -2196,6 +2415,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost; rev. as BWV 194"
   },
@@ -2206,6 +2426,7 @@
     "Forces": "",
     "Key": "D major",
     "Date": "1727–31, rev. 1742, 1748–49",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly lost"
   },
@@ -2216,6 +2437,7 @@
     "Forces": "3vv ch orch",
     "Key": "C major",
     "Date": "1707–08",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2226,6 +2448,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1736–37",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 197a"
   },
@@ -2236,6 +2459,7 @@
     "Forces": "2vv ch orch",
     "Key": "D major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 197; partly lost"
   },
@@ -2246,6 +2470,7 @@
     "Forces": "4vv ch orch",
     "Key": "B minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 244a, BWV 247"
   },
@@ -2256,6 +2481,7 @@
     "Forces": "v orch",
     "Key": "C minor",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2266,6 +2492,7 @@
     "Forces": "v 2vn bc",
     "Key": "E major",
     "Date": "1742–43",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete (aria only)"
   },
@@ -2276,6 +2503,7 @@
     "Forces": "6vv ch orch",
     "Key": "D major",
     "Date": "1729?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2286,6 +2514,7 @@
     "Forces": "v ob str bc",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2296,6 +2525,7 @@
     "Forces": "v hpd",
     "Key": "A minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -2306,6 +2536,7 @@
     "Forces": "v orch",
     "Key": "B♭major",
     "Date": "1726–27",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2316,6 +2547,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "dramma per musica, for the birthday of Professor Augustus Friedrich Müller; parts re-used in BWV 205a"
   },
@@ -2326,6 +2558,7 @@
     "Forces": "",
     "Key": "D major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2336,6 +2569,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version"
   },
@@ -2346,6 +2580,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version"
   },
@@ -2356,6 +2591,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2366,6 +2602,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2376,6 +2613,7 @@
     "Forces": "4vv orch",
     "Key": "F major",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "1st version of BWV 208/2; partly re-used in BWV 208a, BWV Anh.193"
   },
@@ -2386,6 +2624,7 @@
     "Forces": "4vv orch",
     "Key": "F major",
     "Date": "1716?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 208/1"
   },
@@ -2396,6 +2635,7 @@
     "Forces": "",
     "Key": "F major",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the nameday of King August III; based on BWV 208; lost"
   },
@@ -2406,6 +2646,7 @@
     "Forces": "v fl str bc",
     "Key": "B minor",
     "Date": "1729?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2416,6 +2657,7 @@
     "Forces": "v orch",
     "Key": "A major",
     "Date": "1738–41?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "re-used in BWV 210?"
   },
@@ -2426,6 +2668,7 @@
     "Forces": "",
     "Key": "A major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; based on BWV 210?"
   },
@@ -2436,6 +2679,7 @@
     "Forces": "3vv orch",
     "Key": "G major",
     "Date": "1732–34",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2446,6 +2690,7 @@
     "Forces": "2vv orch",
     "Key": "A major",
     "Date": "1742",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2456,6 +2701,7 @@
     "Forces": "5vv ch orch",
     "Key": "F major",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 248/1–5"
   },
@@ -2466,6 +2712,7 @@
     "Forces": "4vv orch",
     "Key": "D major",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2476,6 +2723,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly re-used in BWV 248/1–5"
   },
@@ -2486,6 +2734,7 @@
     "Forces": "2vv (orch?)",
     "Key": "C major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2496,6 +2745,7 @@
     "Forces": "",
     "Key": "",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2506,6 +2756,7 @@
     "Forces": "4vv ch orch",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; probably composed by Johann Christoph Altnikol"
   },
@@ -2516,6 +2767,7 @@
     "Forces": "4vv ch orch",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:634)"
   },
@@ -2526,6 +2778,7 @@
     "Forces": "3vv ch orch",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:1328)"
   },
@@ -2536,6 +2789,7 @@
     "Forces": "3vv ch orch",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composer unidentified"
   },
@@ -2546,6 +2800,7 @@
     "Forces": "2vv orch",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composer unidentified"
   },
@@ -2556,6 +2811,7 @@
     "Forces": "3vv ch org str",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ernst Bach"
   },
@@ -2566,6 +2822,7 @@
     "Forces": "",
     "Key": "B♭major",
     "Date": "1707–08?",
+    "City": "Mühlhausen",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -2576,6 +2833,7 @@
     "Forces": "",
     "Key": "D minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; spurious; probably composed byCarl Philipp Emanuel Bach"
   },
@@ -2586,6 +2844,7 @@
     "Forces": "2ch",
     "Key": "B♭major",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2596,6 +2855,7 @@
     "Forces": "2ch orch",
     "Key": "B♭major",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2606,6 +2866,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2616,6 +2877,7 @@
     "Forces": "2ch",
     "Key": "A major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "A major"
   },
@@ -2626,6 +2888,7 @@
     "Forces": "2ch",
     "Key": "G minor",
     "Date": "1723–24?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2636,6 +2899,7 @@
     "Forces": "ch bc",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2646,6 +2910,7 @@
     "Forces": "2ch",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "based partly on BWV 28 and music byGeorg Philipp Telemann; spurious; probably composed by Johann Gottlob Harrer"
   },
@@ -2656,6 +2921,7 @@
     "Forces": "5vv ch orch",
     "Key": "B minor",
     "Date": "1747–49",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "assembled from previous compositions"
   },
@@ -2666,6 +2932,7 @@
     "Forces": "3vv ch orch",
     "Key": "F major",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 233a, BWV 11, BWV 40, BWV 102, BWV Anh.18"
   },
@@ -2676,6 +2943,7 @@
     "Forces": "ch bc",
     "Key": "F major",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "rev. in BWV 233"
   },
@@ -2686,6 +2954,7 @@
     "Forces": "3vv ch orch",
     "Key": "A major",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 67, BWV 79, BWV 136, BWV 179"
   },
@@ -2696,6 +2965,7 @@
     "Forces": "3vv ch orch",
     "Key": "G minor",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 72, BWV 102, BWV 187"
   },
@@ -2706,6 +2976,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "1738–39?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 17, BWV 79, BWV 138, BWV 179"
   },
@@ -2716,6 +2987,7 @@
     "Forces": "ch orch",
     "Key": "C major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2726,6 +2998,7 @@
     "Forces": "ch orch",
     "Key": "D major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2736,6 +3009,7 @@
     "Forces": "ch str bc",
     "Key": "D minor",
     "Date": "1738–41?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2746,6 +3020,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1742?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -2756,6 +3031,7 @@
     "Forces": "2ch orch",
     "Key": "D major",
     "Date": "1747–48",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "arr. of theSanctusfrom theMissa superbaby Johann Kasper Kerll"
   },
@@ -2766,6 +3042,7 @@
     "Forces": "2vv ch orch",
     "Key": "G minor",
     "Date": "1727–32",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "adapted from a Mass in C minor byFrancesco Durante(see BWV Anh.26)"
   },
@@ -2776,6 +3053,7 @@
     "Forces": "5vv ch orch",
     "Key": "D major",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 243a"
   },
@@ -2786,6 +3064,7 @@
     "Forces": "5vv ch orch",
     "Key": "E♭major",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version of BWV 243"
   },
@@ -2796,6 +3075,7 @@
     "Forces": "vv 2ch 2orch",
     "Key": "",
     "Date": "1736–42",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 244b"
   },
@@ -2806,6 +3086,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1143. Partly based on BWV 198, BWV 247, BWV 244b; lost"
   },
@@ -2816,6 +3097,7 @@
     "Forces": "v 2ch 2orch",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "1st version of BWV 244; text partly re-used in BWV 244a"
   },
@@ -2826,6 +3108,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1724, rev. 1725–49",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2836,6 +3119,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; probably composed by Johann Melchior Molter"
   },
@@ -2846,6 +3130,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 198, BWV 54; lost, but various modern reconstructions exist; partly rev. in BWV 248?"
   },
@@ -2856,6 +3141,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2866,6 +3152,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2876,6 +3163,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2886,6 +3174,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2896,6 +3185,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2906,6 +3196,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "partly based on BWV 213, BWV 215"
   },
@@ -2916,6 +3207,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "based on BWV 248a"
   },
@@ -2926,6 +3218,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "incomplete; rev. as BWV 248/6"
   },
@@ -2936,6 +3229,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for Easter Sunday; based on BWV.249a; 1st version of BWV 249/2"
   },
@@ -2946,6 +3240,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "2nd version of BWV 249/1"
   },
@@ -2956,6 +3251,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost; rev. as BWV.249/1"
   },
@@ -2966,6 +3262,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -2976,6 +3273,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2986,6 +3284,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -2996,6 +3295,7 @@
     "Forces": "ch orch",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3006,6 +3306,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3016,6 +3317,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3026,6 +3328,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3036,6 +3339,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3046,6 +3350,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3056,6 +3361,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3066,6 +3372,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3076,6 +3383,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3086,6 +3394,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3096,6 +3405,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3106,6 +3416,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3116,6 +3427,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3126,6 +3438,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3136,6 +3449,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3146,6 +3460,7 @@
     "Forces": "ch",
     "Key": "G/A♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3156,6 +3471,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3166,6 +3482,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3176,6 +3493,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3186,6 +3504,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3196,6 +3515,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3206,6 +3526,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3216,6 +3537,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3226,6 +3548,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3236,6 +3559,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3246,6 +3570,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3256,6 +3581,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3266,6 +3592,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3276,6 +3603,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3286,6 +3614,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3296,6 +3625,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3306,6 +3636,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3316,6 +3647,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3326,6 +3658,7 @@
     "Forces": "ch",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3336,6 +3669,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3346,6 +3680,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3356,6 +3691,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3366,6 +3702,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3376,6 +3713,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3386,6 +3724,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3396,6 +3735,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3406,6 +3746,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3416,6 +3757,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3426,6 +3768,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3436,6 +3779,7 @@
     "Forces": "ch",
     "Key": "G Mixolydian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3446,6 +3790,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3456,6 +3801,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3466,6 +3812,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3476,6 +3823,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3486,6 +3834,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3496,6 +3845,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3506,6 +3856,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3516,6 +3867,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3526,6 +3878,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3536,6 +3889,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3546,6 +3900,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3556,6 +3911,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3566,6 +3922,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3576,6 +3933,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3586,6 +3944,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3596,6 +3955,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3606,6 +3966,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3616,6 +3977,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3626,6 +3988,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3636,6 +3999,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3646,6 +4010,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3656,6 +4021,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3666,6 +4032,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3676,6 +4043,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3686,6 +4054,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3696,6 +4065,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3706,6 +4076,7 @@
     "Forces": "ch",
     "Key": "F♯minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3716,6 +4087,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3726,6 +4098,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3736,6 +4109,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3746,6 +4120,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3756,6 +4131,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3766,6 +4142,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3776,6 +4153,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3786,6 +4164,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3796,6 +4175,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3806,6 +4186,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3816,6 +4197,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3826,6 +4208,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3836,6 +4219,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3846,6 +4230,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3856,6 +4241,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3866,6 +4252,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3876,6 +4263,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3886,6 +4274,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3896,6 +4285,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3906,6 +4296,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3916,6 +4307,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3926,6 +4318,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3936,6 +4329,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3946,6 +4340,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3956,6 +4351,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3966,6 +4362,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3976,6 +4373,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3986,6 +4384,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -3996,6 +4395,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4006,6 +4406,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4016,6 +4417,7 @@
     "Forces": "ch",
     "Key": "B♭Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4026,6 +4428,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4036,6 +4439,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4046,6 +4450,7 @@
     "Forces": "ch",
     "Key": "C Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4056,6 +4461,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4066,6 +4472,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4076,6 +4483,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4086,6 +4494,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4096,6 +4505,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4106,6 +4516,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4116,6 +4527,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4126,6 +4538,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4136,6 +4549,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4146,6 +4560,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4156,6 +4571,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4166,6 +4582,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4176,6 +4593,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4186,6 +4604,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4196,6 +4615,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4206,6 +4626,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4216,6 +4637,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4226,6 +4648,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4236,6 +4659,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4246,6 +4670,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4256,6 +4681,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4266,6 +4692,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4276,6 +4703,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4286,6 +4714,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4296,6 +4725,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4306,6 +4736,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4316,6 +4747,7 @@
     "Forces": "ch",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4326,6 +4758,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4336,6 +4769,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4346,6 +4780,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4356,6 +4791,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4366,6 +4802,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4376,6 +4813,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4386,6 +4824,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4396,6 +4835,7 @@
     "Forces": "ch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4406,6 +4846,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4416,6 +4857,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4426,6 +4868,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4436,6 +4879,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4446,6 +4890,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4456,6 +4901,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4466,6 +4912,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4476,6 +4923,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4486,6 +4934,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4496,6 +4945,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4506,6 +4956,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4516,6 +4967,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4526,6 +4978,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4536,6 +4989,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4546,6 +5000,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4556,6 +5011,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4566,6 +5022,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4576,6 +5033,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4586,6 +5044,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4596,6 +5055,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4606,6 +5066,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4616,6 +5077,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4626,6 +5088,7 @@
     "Forces": "ch",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4636,6 +5099,7 @@
     "Forces": "ch",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4646,6 +5110,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4656,6 +5121,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4666,6 +5132,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4676,6 +5143,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4686,6 +5154,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4696,6 +5165,7 @@
     "Forces": "ch",
     "Key": "G Mixolydian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4706,6 +5176,7 @@
     "Forces": "ch",
     "Key": "G Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4716,6 +5187,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4726,6 +5198,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4736,6 +5209,7 @@
     "Forces": "ch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4746,6 +5220,7 @@
     "Forces": "ch",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4756,6 +5231,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4766,6 +5242,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4776,6 +5253,7 @@
     "Forces": "ch",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4786,6 +5264,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4796,6 +5275,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4806,6 +5286,7 @@
     "Forces": "ch",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4816,6 +5297,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4826,6 +5308,7 @@
     "Forces": "ch",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4836,6 +5319,7 @@
     "Forces": "ch",
     "Key": "E major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4846,6 +5330,7 @@
     "Forces": "ch",
     "Key": "D Dorian mode",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4856,6 +5341,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -4866,6 +5352,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.831, p.564)"
   },
@@ -4876,6 +5363,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.171, p.114)"
   },
@@ -4886,6 +5374,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.320, p.215)"
   },
@@ -4896,6 +5385,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.570, p.386)"
   },
@@ -4906,6 +5396,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.689, p.473)"
   },
@@ -4916,6 +5407,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.303, p.203)"
   },
@@ -4926,6 +5418,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.355, p.236)"
   },
@@ -4936,6 +5429,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.39, p.24)"
   },
@@ -4946,6 +5440,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.40, p.25)"
   },
@@ -4956,6 +5451,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.43, p.27)"
   },
@@ -4966,6 +5462,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.396, p.258)"
   },
@@ -4976,6 +5473,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.258, p.170)"
   },
@@ -4986,6 +5484,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.13, p.9)"
   },
@@ -4996,6 +5495,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.397, p.259)"
   },
@@ -5006,6 +5506,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.112, p.74)"
   },
@@ -5016,6 +5517,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.187, p.125)"
   },
@@ -5026,6 +5528,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.580, p.396)"
   },
@@ -5036,6 +5539,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.572, p.388)"
   },
@@ -5046,6 +5550,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.847, p.574)"
   },
@@ -5056,6 +5561,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.306, p.206)"
   },
@@ -5066,6 +5572,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.522, p.351)"
   },
@@ -5076,6 +5583,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.647, p.444)"
   },
@@ -5086,6 +5594,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.488, p.325)"
   },
@@ -5096,6 +5605,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.360, p.240)"
   },
@@ -5106,6 +5616,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.78, p.48)"
   },
@@ -5116,6 +5627,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.861, p.584)"
   },
@@ -5126,6 +5638,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.194, p.130)"
   },
@@ -5136,6 +5649,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.657, p.451)"
   },
@@ -5146,6 +5660,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.734, p.502)"
   },
@@ -5156,6 +5671,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.737, p.505)"
   },
@@ -5166,6 +5682,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.195, p.131)"
   },
@@ -5176,6 +5693,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.741, p.509)"
   },
@@ -5186,6 +5704,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.139, p.91)"
   },
@@ -5196,6 +5715,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.119, p.79)"
   },
@@ -5206,6 +5726,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.696, p.478)"
   },
@@ -5216,6 +5737,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.463, p.303)"
   },
@@ -5226,6 +5748,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.333, p.222)"
   },
@@ -5236,6 +5759,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.197, p.133)"
   },
@@ -5246,6 +5770,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.869, p.591)"
   },
@@ -5256,6 +5781,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.868, p.590)"
   },
@@ -5266,6 +5792,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.936, p.638)"
   },
@@ -5276,6 +5803,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.938, p.640)"
   },
@@ -5286,6 +5814,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.281, p.187)"
   },
@@ -5296,6 +5825,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.467, p.306)"
   },
@@ -5306,6 +5836,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.873, p.595)"
   },
@@ -5316,6 +5847,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.874, p.596)"
   },
@@ -5326,6 +5858,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.761, p.521)"
   },
@@ -5336,6 +5869,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.121, p.81)"
   },
@@ -5346,6 +5880,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.283, p.189)"
   },
@@ -5356,6 +5891,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.881, p.601)"
   },
@@ -5366,6 +5902,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.574, p.390)"
   },
@@ -5376,6 +5913,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.700, p.481)"
   },
@@ -5386,6 +5924,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.284, p.190)"
   },
@@ -5396,6 +5935,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.891, p.608)"
   },
@@ -5406,6 +5946,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.203, p.136)"
   },
@@ -5416,6 +5957,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.575, p.392)"
   },
@@ -5426,6 +5968,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.894, p.611)"
   },
@@ -5436,6 +5979,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.472, p.312)"
   },
@@ -5446,6 +5990,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.710, p.488)"
   },
@@ -5456,6 +6001,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.292, p.196)"
   },
@@ -5466,6 +6012,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.293, p.197)"
   },
@@ -5476,6 +6023,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.296, p.199)"
   },
@@ -5486,6 +6034,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "alternative version of BWV 500"
   },
@@ -5496,6 +6045,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.315, p.211)"
   },
@@ -5506,6 +6056,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.901, p.617)"
   },
@@ -5516,6 +6067,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.945, p.646)"
   },
@@ -5526,6 +6078,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.475, p.315)"
   },
@@ -5536,6 +6089,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.627, p.430)"
   },
@@ -5546,6 +6100,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.779, p.553)"
   },
@@ -5556,6 +6111,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Schemelli's Gesang-Buch(No.108, p.69)"
   },
@@ -5566,6 +6122,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "composed byStölzelpossibly arr. by Bach"
   },
@@ -5576,6 +6133,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5586,6 +6144,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5596,6 +6155,7 @@
     "Forces": "v bc",
     "Key": "G minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5606,6 +6166,7 @@
     "Forces": "v bc",
     "Key": "E minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5616,6 +6177,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5626,6 +6188,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5636,6 +6199,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see also BWV 515a"
   },
@@ -5646,6 +6210,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "alternative version of BWV 515"
   },
@@ -5656,6 +6221,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -5666,6 +6232,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5676,6 +6243,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -5686,6 +6254,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5696,6 +6265,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5706,6 +6276,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5716,6 +6287,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5726,6 +6298,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious"
   },
@@ -5736,6 +6309,7 @@
     "Forces": "4vv bc",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "incomplete"
   },
@@ -5746,6 +6320,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5756,6 +6331,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5766,6 +6342,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "2nd movt. rev. in BWV 1044"
   },
@@ -5776,6 +6353,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "partly based on BWV 76"
   },
@@ -5786,6 +6364,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5796,6 +6375,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5806,6 +6386,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5816,6 +6397,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1708-12?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 532a"
   },
@@ -5826,6 +6408,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 532 No.2"
   },
@@ -5836,6 +6419,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "see also BWV 533a"
   },
@@ -5846,6 +6430,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 533"
   },
@@ -5856,6 +6441,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5866,6 +6452,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 535a"
   },
@@ -5876,6 +6463,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 535; incomplete"
   },
@@ -5886,6 +6474,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 536a"
   },
@@ -5896,6 +6485,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 536; Bach's authorship uncertain"
   },
@@ -5906,6 +6496,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5916,6 +6507,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1712–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5926,6 +6518,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Fugue based on part of BWV 1001"
   },
@@ -5936,6 +6529,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–31",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5946,6 +6540,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1712?, rev. 1724–25",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5956,6 +6551,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1720–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5966,6 +6562,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Fugue based on part of BWV 944. Alternate Prelude to BWV 543a."
   },
@@ -5976,6 +6573,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Early Version of BWV 543."
   },
@@ -5986,6 +6584,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1727–31",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -5996,6 +6595,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1712–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 545a, BWV 545b"
   },
@@ -6006,6 +6606,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 545"
   },
@@ -6016,6 +6617,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 545; Bach's authorship is uncertain; possibly composed byJohann Tobias Krebs"
   },
@@ -6026,6 +6628,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1723–29?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6036,6 +6639,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6046,6 +6650,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1727–31",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6056,6 +6661,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 549a"
   },
@@ -6066,6 +6672,7 @@
     "Forces": "org",
     "Key": "D Dorian mode",
     "Date": "1703–07",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 549"
   },
@@ -6076,6 +6683,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6086,6 +6694,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1707?",
+    "City": "Mühlhausen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6096,6 +6705,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1739?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6106,6 +6716,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6116,6 +6727,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6126,6 +6738,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6136,6 +6749,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6146,6 +6760,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6156,6 +6771,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6166,6 +6782,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6176,6 +6793,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6186,6 +6804,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6196,6 +6815,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composer unidentified"
   },
@@ -6206,6 +6826,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1730–45",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Fugue incomplete"
   },
@@ -6216,6 +6837,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1707",
+    "City": "Mühlhausen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6226,6 +6848,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1712?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6236,6 +6859,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6246,6 +6870,7 @@
     "Forces": "org",
     "Key": "E major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; 1st version of BWV 566a"
   },
@@ -6256,6 +6881,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; 2nd version of BWV 566"
   },
@@ -6266,6 +6892,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -6276,6 +6903,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6286,6 +6914,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6296,6 +6925,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1705–08?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6306,6 +6936,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6316,6 +6947,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1712?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6326,6 +6958,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1722?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -6336,6 +6969,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 574a, BWV 574b"
   },
@@ -6346,6 +6980,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 574"
   },
@@ -6356,6 +6991,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 574"
   },
@@ -6366,6 +7002,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6376,6 +7013,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composer unidentified"
   },
@@ -6386,6 +7024,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6396,6 +7035,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1707?",
+    "City": "Mühlhausen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6406,6 +7046,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6416,6 +7057,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6426,6 +7068,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried August Homilius"
   },
@@ -6436,6 +7079,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1708–12?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6446,6 +7090,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1723–29?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6456,6 +7101,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6466,6 +7112,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Friedrich Fasch"
   },
@@ -6476,6 +7123,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; based on music byGeorg Philipp Telemann"
   },
@@ -6486,6 +7134,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; based onLes nationsbyFrançois Couperin"
   },
@@ -6496,6 +7145,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6506,6 +7156,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1709?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -6516,6 +7167,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "after 1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -6526,6 +7178,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1714",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann David Heinichen"
   },
@@ -6536,6 +7189,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of a lost violin concerto by Prince Johann Ernst of Saxe-Weimar; arr. for hpd as BWV 592a"
   },
@@ -6546,6 +7200,7 @@
     "Forces": "hpd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of BWV 592"
   },
@@ -6556,6 +7211,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theConcerto for 2 Violins in A minor, RV 522, byAntonio Vivaldi"
   },
@@ -6566,6 +7222,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in D major, RV 208, byAntonio Vivaldi"
   },
@@ -6576,6 +7233,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of No.4 of the 6 Violiin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar; see also BWV 987"
   },
@@ -6586,6 +7244,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theConcerto for 2 Violins and Cello in D minor, RV 565, byAntonio Vivaldi"
   },
@@ -6596,6 +7255,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "arr. of a concerto by an unidentified composer; Bach's authorship uncertain"
   },
@@ -6606,6 +7266,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1735?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possbily composed byCarl Philipp Emanuel Bach"
   },
@@ -6616,6 +7277,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6626,6 +7288,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6636,6 +7299,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6646,6 +7310,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6656,6 +7321,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6666,6 +7332,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6676,6 +7343,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6686,6 +7354,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6696,6 +7365,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6706,6 +7376,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6716,6 +7387,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6726,6 +7398,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6736,6 +7409,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6746,6 +7420,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6756,6 +7431,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6766,6 +7442,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6776,6 +7453,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6786,6 +7464,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6796,6 +7475,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6806,6 +7486,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6816,6 +7497,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6826,6 +7508,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6836,6 +7519,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6846,6 +7530,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1714-16?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6856,6 +7541,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6866,6 +7552,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6876,6 +7563,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6886,6 +7574,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6896,6 +7585,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6906,6 +7596,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6916,6 +7607,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6926,6 +7618,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6936,6 +7629,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6946,6 +7640,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6956,6 +7651,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6966,6 +7662,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6976,6 +7673,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1727–30",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6986,6 +7684,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -6996,6 +7695,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7006,6 +7706,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7016,6 +7717,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7026,6 +7728,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7036,6 +7739,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7046,6 +7750,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7056,6 +7761,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7066,6 +7772,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1710–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7076,6 +7783,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7086,6 +7794,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7096,6 +7805,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7106,6 +7816,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7116,6 +7827,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7126,6 +7838,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7136,6 +7849,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7146,6 +7860,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.IV of BWV 140"
   },
@@ -7156,6 +7871,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7166,6 +7882,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.IV of BWV 93"
   },
@@ -7176,6 +7893,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.V of BWV 10"
   },
@@ -7186,6 +7904,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.III of BWV 6"
   },
@@ -7196,6 +7915,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "based on movt.II of BWV 137"
   },
@@ -7206,6 +7926,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7216,6 +7937,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7226,6 +7948,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7236,6 +7959,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7246,6 +7970,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7256,6 +7981,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7266,6 +7992,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1719?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7276,6 +8003,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7286,6 +8014,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7296,6 +8025,7 @@
     "Forces": "org",
     "Key": "E♭major",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7306,6 +8036,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7316,6 +8047,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7326,6 +8058,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7336,6 +8069,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7346,6 +8080,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7356,6 +8091,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7366,6 +8102,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7376,6 +8113,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7386,6 +8124,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7396,6 +8135,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7406,6 +8146,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7416,6 +8157,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7426,6 +8168,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7436,6 +8179,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Ludwig Krebs"
   },
@@ -7446,6 +8190,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7456,6 +8201,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7466,6 +8212,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7476,6 +8223,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7486,6 +8234,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7496,6 +8245,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7506,6 +8256,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "1746/47?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7516,6 +8267,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7526,6 +8278,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7536,6 +8289,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7546,6 +8300,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7556,6 +8311,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7566,6 +8322,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7576,6 +8333,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7586,6 +8344,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1749?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7596,6 +8355,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7606,6 +8366,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -7616,6 +8377,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1750",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7626,6 +8388,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7636,6 +8399,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7646,6 +8410,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7656,6 +8421,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7666,6 +8432,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7676,6 +8443,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7686,6 +8454,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7696,6 +8465,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7706,6 +8476,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7716,6 +8487,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Variant. Bach's authorship of this work is doubtful"
   },
@@ -7726,6 +8498,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7736,6 +8509,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7746,6 +8520,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7756,6 +8531,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7766,6 +8542,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7776,6 +8553,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7786,6 +8564,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7796,6 +8575,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Variant. Bach's authorship of this work is doubtful"
   },
@@ -7806,6 +8586,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7816,6 +8597,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7826,6 +8608,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7836,6 +8619,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7846,6 +8630,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7856,6 +8641,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7866,6 +8652,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7876,6 +8663,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7886,6 +8674,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 691"
   },
@@ -7896,6 +8685,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1749?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 691; Bach's authorship uncertain"
   },
@@ -7906,6 +8696,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -7916,6 +8707,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -7926,6 +8718,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -7936,6 +8729,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7946,6 +8740,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7956,6 +8751,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -7966,6 +8762,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7976,6 +8773,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7986,6 +8784,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -7996,6 +8795,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8006,6 +8806,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8016,6 +8817,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8026,6 +8828,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8036,6 +8839,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8046,6 +8850,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1739–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8056,6 +8861,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8066,6 +8872,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8076,6 +8883,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8086,6 +8894,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1731?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8096,6 +8905,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1731?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8106,6 +8916,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8116,6 +8927,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "spurious; composer unidentfied"
   },
@@ -8126,6 +8938,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byNicolaus Vetter"
   },
@@ -8136,6 +8949,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8146,6 +8960,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8156,6 +8971,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8166,6 +8982,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "Various",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8176,6 +8993,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8186,6 +9004,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1727?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8196,6 +9015,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8206,6 +9026,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8216,6 +9037,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1712–13",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8226,6 +9048,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8236,6 +9059,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Michael Bach"
   },
@@ -8246,6 +9070,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8256,6 +9081,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8266,6 +9092,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8276,6 +9103,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Michael Bach"
   },
@@ -8286,6 +9114,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8296,6 +9125,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8306,6 +9136,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8316,6 +9147,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8326,6 +9158,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8336,6 +9169,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8346,6 +9180,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8356,6 +9191,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8366,6 +9202,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8376,6 +9213,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8386,6 +9224,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -8396,6 +9235,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8406,6 +9246,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8416,6 +9257,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1708–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8426,6 +9268,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8436,6 +9279,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8446,6 +9290,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8456,6 +9301,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8466,6 +9312,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8476,6 +9323,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -8486,6 +9334,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8496,6 +9345,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1733?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8506,6 +9356,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8516,6 +9367,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Ludwig Krebs"
   },
@@ -8526,6 +9378,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; probably composed byCarl Philipp Emanuel Bach"
   },
@@ -8536,6 +9389,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Caspar Ferdinand Fischer"
   },
@@ -8546,6 +9400,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1731–40?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8556,6 +9411,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther; see also BWV 748a"
   },
@@ -8566,6 +9422,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "variant of BWV 748; spurious; composed byJohann Gottfried Walther"
   },
@@ -8576,6 +9433,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain, possibly composed byJohann Christoph BachorGeorg Philipp Telemann"
   },
@@ -8586,6 +9444,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8596,6 +9455,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Michael Bach"
   },
@@ -8606,6 +9466,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8616,6 +9477,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -8626,6 +9488,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8636,6 +9499,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8646,6 +9510,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8656,6 +9521,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8666,6 +9532,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8676,6 +9543,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried August Homilius; see also BWV Anh.74"
   },
@@ -8686,6 +9554,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Böhm"
   },
@@ -8696,6 +9565,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Böhm"
   },
@@ -8706,6 +9576,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8716,6 +9587,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1737?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8726,6 +9598,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -8736,6 +9609,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -8746,6 +9620,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1700?",
+    "City": "Lüneburg",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8756,6 +9631,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8766,6 +9642,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8776,6 +9653,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 769a"
   },
@@ -8786,6 +9664,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 769"
   },
@@ -8796,6 +9675,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8806,6 +9686,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byNicolaus Vetter"
   },
@@ -8816,6 +9697,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8826,6 +9708,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 772a"
   },
@@ -8836,6 +9719,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 772; Bach's authorship uncertain"
   },
@@ -8846,6 +9730,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8856,6 +9741,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8866,6 +9752,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8876,6 +9763,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8886,6 +9774,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8896,6 +9785,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8906,6 +9796,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8916,6 +9807,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8926,6 +9818,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8936,6 +9829,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8946,6 +9840,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8956,6 +9851,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8966,6 +9862,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8976,6 +9873,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8986,6 +9884,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -8996,6 +9895,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9006,6 +9906,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9016,6 +9917,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9026,6 +9928,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9036,6 +9939,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9046,6 +9950,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9056,6 +9961,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9066,6 +9972,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9076,6 +9983,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9086,6 +9994,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9096,6 +10005,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9106,6 +10016,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9116,6 +10027,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9126,6 +10038,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9136,6 +10049,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1720–23",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9146,6 +10060,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.23 inClavier-Übung III"
   },
@@ -9156,6 +10071,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.24 inClavier-Übung III"
   },
@@ -9166,6 +10082,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.25 inClavier-Übung III"
   },
@@ -9176,6 +10093,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.26 inClavier-Übung III"
   },
@@ -9186,6 +10104,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 806a"
   },
@@ -9196,6 +10115,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1714–17?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 806"
   },
@@ -9206,6 +10126,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9216,6 +10137,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9226,6 +10148,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9236,6 +10159,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9246,6 +10170,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9256,6 +10181,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9266,6 +10192,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 813a"
   },
@@ -9276,6 +10203,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 813"
   },
@@ -9286,6 +10214,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 814a"
   },
@@ -9296,6 +10225,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 814"
   },
@@ -9306,6 +10236,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 815a"
   },
@@ -9316,6 +10247,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 815"
   },
@@ -9326,6 +10258,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9336,6 +10269,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1722–25?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9346,6 +10280,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 818"
   },
@@ -9356,6 +10291,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720–22?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 818"
   },
@@ -9366,6 +10302,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 819"
   },
@@ -9376,6 +10313,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1725–28?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 819"
   },
@@ -9386,6 +10324,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9396,6 +10335,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9406,6 +10346,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9416,6 +10357,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -9426,6 +10368,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 32:14)"
   },
@@ -9436,6 +10379,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.1 inClavier-Übung I"
   },
@@ -9446,6 +10390,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.2 inClavier-Übung I"
   },
@@ -9456,6 +10401,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1725–27",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.3 inClavier-Übung I"
   },
@@ -9466,6 +10412,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1728",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.4 inClavier-Übung I"
   },
@@ -9476,6 +10423,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.5 inClavier-Übung I"
   },
@@ -9486,6 +10434,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1725–30",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.6 inClavier-Übung I"
   },
@@ -9496,6 +10445,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "2nd version of BWV 831a; No.2 inClavier-Übung II"
   },
@@ -9506,6 +10456,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "1st version of BWV 831"
   },
@@ -9516,6 +10467,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9526,6 +10478,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1708–14?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byBernardo Pasquini"
   },
@@ -9536,6 +10489,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9546,6 +10500,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger"
   },
@@ -9556,6 +10511,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–22",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "composed withWilhelm Friedemann Bach"
   },
@@ -9566,6 +10522,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720–22",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "composed withWilhelm Friedemann Bach; incomplete"
   },
@@ -9576,6 +10533,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristoph Graupner(GWV 849/2–3)"
   },
@@ -9586,6 +10544,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1735?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9596,6 +10555,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 32:13)"
   },
@@ -9606,6 +10566,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Part of the3 Minuets"
   },
@@ -9616,6 +10577,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Part of the3 Minuets"
   },
@@ -9626,6 +10588,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Part of the3 Minuets"
   },
@@ -9636,6 +10599,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach; see also BWV 844a"
   },
@@ -9646,6 +10610,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 844; Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -9656,6 +10621,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -9666,6 +10632,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -9676,6 +10643,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 846a"
   },
@@ -9686,6 +10654,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 846"
   },
@@ -9696,6 +10665,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 847a"
   },
@@ -9706,6 +10676,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 847"
   },
@@ -9716,6 +10687,7 @@
     "Forces": "kbd",
     "Key": "C♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 848a"
   },
@@ -9726,6 +10698,7 @@
     "Forces": "kbd",
     "Key": "C♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 848"
   },
@@ -9736,6 +10709,7 @@
     "Forces": "kbd",
     "Key": "C♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 849a"
   },
@@ -9746,6 +10720,7 @@
     "Forces": "kbd",
     "Key": "C♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 849"
   },
@@ -9756,6 +10731,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 850a"
   },
@@ -9766,6 +10742,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 850"
   },
@@ -9776,6 +10753,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 851a"
   },
@@ -9786,6 +10764,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 851"
   },
@@ -9796,6 +10775,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 852a"
   },
@@ -9806,6 +10786,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 852"
   },
@@ -9816,6 +10797,7 @@
     "Forces": "kbd",
     "Key": "E♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 853a"
   },
@@ -9826,6 +10808,7 @@
     "Forces": "kbd",
     "Key": "E♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 853"
   },
@@ -9836,6 +10819,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 854a"
   },
@@ -9846,6 +10830,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 854"
   },
@@ -9856,6 +10841,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 855a"
   },
@@ -9866,6 +10852,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 855"
   },
@@ -9876,6 +10863,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 856a"
   },
@@ -9886,6 +10874,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 856"
   },
@@ -9896,6 +10885,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 857a"
   },
@@ -9906,6 +10896,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 857"
   },
@@ -9916,6 +10907,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 858a"
   },
@@ -9926,6 +10918,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 858"
   },
@@ -9936,6 +10929,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 859a"
   },
@@ -9946,6 +10940,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 859"
   },
@@ -9956,6 +10951,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 860a"
   },
@@ -9966,6 +10962,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 860"
   },
@@ -9976,6 +10973,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 861a"
   },
@@ -9986,6 +10984,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 861"
   },
@@ -9996,6 +10995,7 @@
     "Forces": "kbd",
     "Key": "A♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 862a"
   },
@@ -10006,6 +11006,7 @@
     "Forces": "kbd",
     "Key": "A♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 862"
   },
@@ -10016,6 +11017,7 @@
     "Forces": "kbd",
     "Key": "G♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 863a"
   },
@@ -10026,6 +11028,7 @@
     "Forces": "kbd",
     "Key": "G♯minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 863"
   },
@@ -10036,6 +11039,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 864a"
   },
@@ -10046,6 +11050,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 864"
   },
@@ -10056,6 +11061,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 865a"
   },
@@ -10066,6 +11072,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 865"
   },
@@ -10076,6 +11083,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 866a"
   },
@@ -10086,6 +11094,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 866"
   },
@@ -10096,6 +11105,7 @@
     "Forces": "kbd",
     "Key": "B♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 867a"
   },
@@ -10106,6 +11116,7 @@
     "Forces": "kbd",
     "Key": "B♭minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 867"
   },
@@ -10116,6 +11127,7 @@
     "Forces": "kbd",
     "Key": "B major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 868a"
   },
@@ -10126,6 +11138,7 @@
     "Forces": "kbd",
     "Key": "B major",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 868"
   },
@@ -10136,6 +11149,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 869a"
   },
@@ -10146,6 +11160,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 869"
   },
@@ -10156,6 +11171,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10166,6 +11182,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 870a, 870b"
   },
@@ -10176,6 +11193,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 870"
   },
@@ -10186,6 +11204,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 870"
   },
@@ -10196,6 +11215,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10206,6 +11226,7 @@
     "Forces": "kbd",
     "Key": "C♯major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 872a"
   },
@@ -10216,6 +11237,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 872"
   },
@@ -10226,6 +11248,7 @@
     "Forces": "kbd",
     "Key": "C♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10236,6 +11259,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10246,6 +11270,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 875a"
   },
@@ -10256,6 +11281,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 875"
   },
@@ -10266,6 +11292,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10276,6 +11303,7 @@
     "Forces": "kbd",
     "Key": "D♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10286,6 +11314,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10296,6 +11325,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10306,6 +11336,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10316,6 +11347,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10326,6 +11358,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10336,6 +11369,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10346,6 +11380,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10356,6 +11391,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10366,6 +11402,7 @@
     "Forces": "kbd",
     "Key": "A♭major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10376,6 +11413,7 @@
     "Forces": "kbd",
     "Key": "G♯minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10386,6 +11424,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10396,6 +11435,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10406,6 +11446,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10416,6 +11457,7 @@
     "Forces": "kbd",
     "Key": "B♭minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10426,6 +11468,7 @@
     "Forces": "kbd",
     "Key": "B major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10436,6 +11479,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10446,6 +11490,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1715–25",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "rev. in BWV 1044"
   },
@@ -10456,6 +11501,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1709",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10466,6 +11512,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10476,6 +11523,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "prelude composed byCornelius Heinrich Dretzel; composer of fugue uncertain"
   },
@@ -10486,6 +11534,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Christian Kittel"
   },
@@ -10496,6 +11545,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1725–26?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10506,6 +11556,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1725–26?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10516,6 +11567,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10526,6 +11578,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 902/1a"
   },
@@ -10536,6 +11589,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of prelude from BWV 902"
   },
@@ -10546,6 +11600,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "see also BWV 903a"
   },
@@ -10556,6 +11611,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 903"
   },
@@ -10566,6 +11622,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10576,6 +11633,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10586,6 +11644,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "fugue incompete"
   },
@@ -10596,6 +11655,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried Kirchhoff"
   },
@@ -10606,6 +11666,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried Kirchhoff"
   },
@@ -10616,6 +11677,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1703",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10626,6 +11688,7 @@
     "Forces": "kbd",
     "Key": "F♯minor",
     "Date": "1712",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10636,6 +11699,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10646,6 +11710,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 912a"
   },
@@ -10656,6 +11721,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "early version of the Adagio from BWV 912"
   },
@@ -10666,6 +11732,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see also BWV 913a"
   },
@@ -10676,6 +11743,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 913"
   },
@@ -10686,6 +11754,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10696,6 +11765,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10706,6 +11776,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10716,6 +11787,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1710?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10726,6 +11798,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10736,6 +11809,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; byJohann Bernhard Bach"
   },
@@ -10746,6 +11820,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -10756,6 +11831,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10766,6 +11842,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1710–14?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10776,6 +11853,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed by Wilhelm Heironymous Pachelbel; see also BWV 923a"
   },
@@ -10786,6 +11864,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 923; Bach's authorship uncertain"
   },
@@ -10796,6 +11875,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10806,6 +11886,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see also BWV 924a"
   },
@@ -10816,6 +11897,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 924; Bach's authorship uncertain"
   },
@@ -10826,6 +11908,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -10836,6 +11919,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10846,6 +11930,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10856,6 +11941,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10866,6 +11952,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10876,6 +11963,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10886,6 +11974,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -10896,6 +11985,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete; Bach's authorship uncertain; possibly composed byWilhelm Friedemann Bach"
   },
@@ -10906,6 +11996,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10916,6 +12007,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10926,6 +12018,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10936,6 +12029,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10946,6 +12040,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10956,6 +12051,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10966,6 +12062,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10976,6 +12073,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10986,6 +12084,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -10996,6 +12095,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11006,6 +12106,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1717",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11016,6 +12117,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1717?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11026,6 +12128,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1703–07",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11036,6 +12139,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Fugue rev. in BWV 543"
   },
@@ -11046,6 +12150,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1695–1700?",
+    "City": "Ohrdruf",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain (possibly composed byChristoph Graupner"
   },
@@ -11056,6 +12161,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1708?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "on a theme byTomaso Albinoni"
   },
@@ -11066,6 +12172,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11076,6 +12183,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1727?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11086,6 +12194,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11096,6 +12205,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "on a theme byTomaso Albinoni"
   },
@@ -11106,6 +12216,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1712",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "on a theme byTomaso Albinoni; see also BWV 951a"
   },
@@ -11116,6 +12227,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1712",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "alternative version of BWV 951"
   },
@@ -11126,6 +12238,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11136,6 +12249,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1723?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11146,6 +12260,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "on a theme byJohann Adam Reincken"
   },
@@ -11156,6 +12271,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "previously thought to have been arr. from a work byJohann Christoph Erselius; see also BWV 955a"
   },
@@ -11166,6 +12282,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "early variant of BWV 955"
   },
@@ -11176,6 +12293,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11186,6 +12304,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "previously believed to be a fugue hpd"
   },
@@ -11196,6 +12315,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11206,6 +12326,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11216,6 +12337,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "incomplete; Bach's authorship uncertain"
   },
@@ -11226,6 +12348,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1712?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11236,6 +12359,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "1783",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Georg Albrechtsberger"
   },
@@ -11246,6 +12370,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11256,6 +12381,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "arr. of BWV 1003"
   },
@@ -11266,6 +12392,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "arr. of the Sonata No.1 fromHortus MusicusbyJohann Adam Reincken"
   },
@@ -11276,6 +12403,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "arr. of the Sonata No.3 fromHortus MusicusbyJohann Adam Reincken"
   },
@@ -11286,6 +12414,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1705?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "arr. of an unidentified work by an unknown composer"
   },
@@ -11296,6 +12425,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "arr. of the 1st movt. of BWV 1005"
   },
@@ -11306,6 +12436,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -11316,6 +12447,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.25/2)"
   },
@@ -11326,6 +12458,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "No.1 inClavier-ÜbungII"
   },
@@ -11336,6 +12469,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arrs. of works by other composers"
   },
@@ -11346,6 +12480,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Revised version, arr. of theViolin Concerto in D major, RV 230, byAntonio Vivaldi"
   },
@@ -11356,6 +12491,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1711",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "Early version, arr. of theViolin Concerto in D major, RV 230, byAntonio Vivaldi"
   },
@@ -11366,6 +12502,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theViolin Concerto in G major, RV 299, byAntonio Vivaldi"
   },
@@ -11376,6 +12513,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theOboe Concerto in D minorbyAlessandro Marcello"
   },
@@ -11386,6 +12524,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in G minor, RV 316, byAntonio Vivaldi"
   },
@@ -11396,6 +12535,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theViolin Concerto in E major, RV 265, byAntonio Vivaldi"
   },
@@ -11406,6 +12546,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "source unidentified"
   },
@@ -11416,6 +12557,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of theViolin Concerto in G major, RV 310, byAntonio Vivaldi"
   },
@@ -11426,6 +12568,7 @@
     "Forces": "kbd",
     "Key": "B minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of a Violin Concerto in D minor byGiuseppe Torelli"
   },
@@ -11436,6 +12579,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in B♭minor, RV 381, byAntonio Vivaldi"
   },
@@ -11446,6 +12590,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in C minor, Op.1 No.2, byBenedetto Marcello"
   },
@@ -11456,6 +12601,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of No.1 of the 6 Violin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar"
   },
@@ -11466,6 +12612,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "source unidentified"
   },
@@ -11476,6 +12623,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of a lost concerto by Prince Johann Ernst of Saxe-Weimar"
   },
@@ -11486,6 +12634,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of the Violin Concerto in G minor, TWV 51:g21, byGeorg Philipp Telemann"
   },
@@ -11496,6 +12645,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "source unidentified"
   },
@@ -11506,6 +12656,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1713–14",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "arr. of No.4 of the 6 Violin Concertos, Op.1, by Prince Johann Ernst of Saxe-Weimar; see also BWV 595"
   },
@@ -11516,6 +12667,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1741–42",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "published inClavier-ÜbungIV"
   },
@@ -11526,6 +12678,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1714?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11536,6 +12689,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11546,6 +12700,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -11556,6 +12711,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11566,6 +12722,7 @@
     "Forces": "kbd",
     "Key": "E major",
     "Date": "1721?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11576,6 +12733,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "1720–21",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -11586,6 +12744,7 @@
     "Forces": "lute",
     "Key": "G minor",
     "Date": "1727–31?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1011"
   },
@@ -11596,6 +12755,7 @@
     "Forces": "lute/hpd",
     "Key": "E minor",
     "Date": "1712–17?",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11606,6 +12766,7 @@
     "Forces": "lute/hpd",
     "Key": "C minor",
     "Date": "1740?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11616,6 +12777,7 @@
     "Forces": "lute/kbd",
     "Key": "E♭major",
     "Date": "1740–45?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11626,6 +12788,7 @@
     "Forces": "lute",
     "Key": "C minor",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11636,6 +12799,7 @@
     "Forces": "lute",
     "Key": "G minor",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. of 2nd movt. from BWV 1001"
   },
@@ -11646,6 +12810,7 @@
     "Forces": "vn",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "(link to complete collections of all 6 sonatas and partitas)"
   },
@@ -11656,6 +12821,7 @@
     "Forces": "vn",
     "Key": "G minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "partly rev. in BWV 539; 2nd movt. arr. for lute as BWV 1000"
   },
@@ -11666,6 +12832,7 @@
     "Forces": "vn",
     "Key": "B minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11676,6 +12843,7 @@
     "Forces": "vn",
     "Key": "A minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. for kbd as BWV 964"
   },
@@ -11686,6 +12854,7 @@
     "Forces": "vn",
     "Key": "D minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11696,6 +12865,7 @@
     "Forces": "vn",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "1st movt. arr. for kbd as BWV 968"
   },
@@ -11706,6 +12876,7 @@
     "Forces": "vn",
     "Key": "E major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. for lute as BWV 1006a; 1st movt. arr. for org orch as Sinfonia of BWV 29"
   },
@@ -11716,6 +12887,7 @@
     "Forces": "lute",
     "Key": "E major",
     "Date": "1736–37",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1006"
   },
@@ -11726,6 +12898,7 @@
     "Forces": "vc",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "(link to complete collections of all 6 suites)"
   },
@@ -11736,6 +12909,7 @@
     "Forces": "vc",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11746,6 +12920,7 @@
     "Forces": "vc",
     "Key": "D minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11756,6 +12931,7 @@
     "Forces": "vc",
     "Key": "C major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11766,6 +12942,7 @@
     "Forces": "vc",
     "Key": "E♭major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11776,6 +12953,7 @@
     "Forces": "vc",
     "Key": "C minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "arr. for lute as BWV 995"
   },
@@ -11786,6 +12964,7 @@
     "Forces": "vc",
     "Key": "D major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11796,6 +12975,7 @@
     "Forces": "fl",
     "Key": "A minor",
     "Date": "1722–23",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11806,6 +12986,7 @@
     "Forces": "vn kbd",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11816,6 +12997,7 @@
     "Forces": "vn kbd",
     "Key": "B minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11826,6 +13008,7 @@
     "Forces": "vn kbd",
     "Key": "A major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11836,6 +13019,7 @@
     "Forces": "vn kbd",
     "Key": "E major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11846,6 +13030,7 @@
     "Forces": "vn kbd",
     "Key": "C minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11856,6 +13041,7 @@
     "Forces": "vn kbd",
     "Key": "F minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "see also BWV 1018a"
   },
@@ -11866,6 +13052,7 @@
     "Forces": "vn kbd",
     "Key": "F minor",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "alternative version of BWV 1018, 3rd movt."
   },
@@ -11876,6 +13063,7 @@
     "Forces": "vn kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "see also BWV 1019a"
   },
@@ -11886,6 +13074,7 @@
     "Forces": "vn kbd",
     "Key": "G major",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Chamber",
     "Notes": "alternative version of BWV 1019"
   },
@@ -11896,6 +13085,7 @@
     "Forces": "vn/fl kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.542.5)"
   },
@@ -11906,6 +13096,7 @@
     "Forces": "vn bc",
     "Key": "G major",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "shares the bc part with BWV 1022 and BWV 1038"
   },
@@ -11916,6 +13107,7 @@
     "Forces": "vn kbd",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1038; Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
   },
@@ -11926,6 +13118,7 @@
     "Forces": "vn bc",
     "Key": "E minor",
     "Date": "1714–17?",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11936,6 +13129,7 @@
     "Forces": "vn bc",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11946,6 +13140,7 @@
     "Forces": "vn kbd",
     "Key": "A major",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. of the Lute Sonata in A major, SC 47, by Silvius Leopold Weiss"
   },
@@ -11956,6 +13151,7 @@
     "Forces": "vn bc",
     "Key": "G minor",
     "Date": "before 1712",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11966,6 +13162,7 @@
     "Forces": "viol hpd",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -11976,6 +13173,7 @@
     "Forces": "viol hpd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "arr. of BWV 1039; see also BWV 1027a"
   },
@@ -11986,6 +13184,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "arrs. of movts. 1, 2 and 4 from BWV 1027a; Bach's authorship uncertain"
   },
@@ -11996,6 +13195,7 @@
     "Forces": "viol hpd",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12006,6 +13206,7 @@
     "Forces": "viol hpd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12016,6 +13217,7 @@
     "Forces": "fl hpd",
     "Key": "B minor",
     "Date": "1736–37",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12026,6 +13228,7 @@
     "Forces": "ob hpd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12036,6 +13239,7 @@
     "Forces": "fl hpd",
     "Key": "E♭major",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12046,6 +13250,7 @@
     "Forces": "fl hpd",
     "Key": "A major",
     "Date": "1736?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12056,6 +13261,7 @@
     "Forces": "fl bc",
     "Key": "C major",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12066,6 +13272,7 @@
     "Forces": "fl bc",
     "Key": "E minor",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12076,6 +13283,7 @@
     "Forces": "fl bc",
     "Key": "E major",
     "Date": "1741",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12086,6 +13294,7 @@
     "Forces": "2vn bc",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.145, H.569)"
   },
@@ -12096,6 +13305,7 @@
     "Forces": "2vn bc",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byJohann Gottlieb Goldberg"
   },
@@ -12106,6 +13316,7 @@
     "Forces": "fl vn bc",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "bc part virtually identical to that of BWV 1021; Bach's authorship for upper two voices uncertain; possibly composed byCarl Philipp Emanuel Bach(H.590.5); arr. for vn hpd as BWV 1022"
   },
@@ -12116,6 +13327,7 @@
     "Forces": "2fl bc",
     "Key": "G major",
     "Date": "1736–41?",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "arr. for viol hpd as BWV 1027"
   },
@@ -12126,6 +13338,7 @@
     "Forces": "ob vn bc",
     "Key": "F major",
     "Date": "1713–16?",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12136,6 +13349,7 @@
     "Forces": "vn str bc",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "arr. for hpd str bc as BWV 1058"
   },
@@ -12146,6 +13360,7 @@
     "Forces": "vn str bc",
     "Key": "E major",
     "Date": "1720?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "arr. for hpd str bc as BWV 1054"
   },
@@ -12156,6 +13371,7 @@
     "Forces": "2vn bc str",
     "Key": "D minor",
     "Date": "1718–20?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "arr. for hpd str bc as BWV 1062"
   },
@@ -12166,6 +13382,7 @@
     "Forces": "fl hpd vn str bc",
     "Key": "A minor",
     "Date": "1738–40?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "movts. based on BWV 894/1, 527/2, 894/3 respectively"
   },
@@ -12176,6 +13393,7 @@
     "Forces": "vn orch",
     "Key": "D major",
     "Date": "1743–46?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "from a lost cantata; Bach's authorship uncertain"
   },
@@ -12186,6 +13404,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "1721",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "2nd version of BWV 1046"
   },
@@ -12196,6 +13415,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "1st version of BWV 1046"
   },
@@ -12206,6 +13426,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12216,6 +13437,7 @@
     "Forces": "hpd str",
     "Key": "G major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "1st movt. arr. for orch as Sinfonia of BWV 174"
   },
@@ -12226,6 +13448,7 @@
     "Forces": "orch",
     "Key": "G major",
     "Date": "1719–20",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "arr. for 2rec hpd str bc as BWV 1057"
   },
@@ -12236,6 +13459,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1720–21",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "see also BWV 1050a"
   },
@@ -12246,6 +13470,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1719?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "early version of BWV 1050"
   },
@@ -12256,6 +13481,7 @@
     "Forces": "hpd str",
     "Key": "B♭major",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12266,6 +13492,7 @@
     "Forces": "hpd str bc",
     "Key": "D minor",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost Violin Concerto (see BWV 1052R); partly re-used in BWV 146, BWV 188; see also BWV 1052a"
   },
@@ -12276,6 +13503,7 @@
     "Forces": "hpd str bc",
     "Key": "D minor",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "earlier version of BWV 1052; possibly an arr. by C. P. E. Bach"
   },
@@ -12286,6 +13514,7 @@
     "Forces": "vn str bc",
     "Key": "D minor",
     "Date": "1730–34?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 146, 188, 1052a and 1052"
   },
@@ -12296,6 +13525,7 @@
     "Forces": "hpd str bc",
     "Key": "E major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost Oboe Concerto (see BWV 1053R); partly re-used in BWV 49, BWV 169"
   },
@@ -12306,6 +13536,7 @@
     "Forces": "ob/oda str bc",
     "Key": "F major",
     "Date": "1730–38?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 49, 169 and 1053. Also has been reconstructed for Oboe d'amore."
   },
@@ -12316,6 +13547,7 @@
     "Forces": "hpd str bc",
     "Key": "D major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1042"
   },
@@ -12326,6 +13558,7 @@
     "Forces": "hpd str bc",
     "Key": "A major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost concerto for oboe d'amore (see BWV 1055R)"
   },
@@ -12336,6 +13569,7 @@
     "Forces": "oda str bc",
     "Key": "A major",
     "Date": "1730–38?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1055"
   },
@@ -12346,6 +13580,7 @@
     "Forces": "hpd str bc",
     "Key": "F minor",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost violin concerto; partly re-used in BWV 156"
   },
@@ -12356,6 +13591,7 @@
     "Forces": "vn str bc",
     "Key": "G minor",
     "Date": "1730–38?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1056"
   },
@@ -12366,6 +13602,7 @@
     "Forces": "2rec hpd str bc",
     "Key": "F major",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1049"
   },
@@ -12376,6 +13613,7 @@
     "Forces": "hpd str bc",
     "Key": "G minor",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1041"
   },
@@ -12386,6 +13624,7 @@
     "Forces": "hpd ob str bc",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost oboe concerto (see BWV 1059R); incomplete; partly rev. as BWV 35"
   },
@@ -12396,6 +13635,7 @@
     "Forces": "ob str bc",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 35, 156, and 1059"
   },
@@ -12406,6 +13646,7 @@
     "Forces": "2hpd str bc",
     "Key": "C minor",
     "Date": "1730–45?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost concerto for oboe and violin (see BWV 1060R)"
   },
@@ -12416,6 +13657,7 @@
     "Forces": "ob vn str bc",
     "Key": "C minor",
     "Date": "1719?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1060"
   },
@@ -12426,6 +13668,7 @@
     "Forces": "2hpd str bc",
     "Key": "C major",
     "Date": "1733–34",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "2nd version of BWV 1061a"
   },
@@ -12436,6 +13679,7 @@
     "Forces": "2hpd",
     "Key": "C major",
     "Date": "1732–33",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "1st version of BWV 1061"
   },
@@ -12446,6 +13690,7 @@
     "Forces": "2hpd str bc",
     "Key": "C minor",
     "Date": "1736",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of BWV 1043"
   },
@@ -12456,6 +13701,7 @@
     "Forces": "3hpd str bc",
     "Key": "D minor",
     "Date": "1735–45?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12466,6 +13712,7 @@
     "Forces": "3hpd str bc",
     "Key": "C major",
     "Date": "1735–45?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of a lost concerto for 3vn (see BWV 1064R)"
   },
@@ -12476,6 +13723,7 @@
     "Forces": "3vn str bc",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "lost, but reconstructed from BWV 1064"
   },
@@ -12486,6 +13734,7 @@
     "Forces": "4hpd str bc",
     "Key": "A minor",
     "Date": "1730?",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": "arr. of theConcerto for 4 Violins and Cello in B minor, RV 580, byAntonio Vivaldi"
   },
@@ -12496,6 +13745,7 @@
     "Forces": "orch",
     "Key": "C major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12506,6 +13756,7 @@
     "Forces": "orch",
     "Key": "B minor",
     "Date": "1738–39",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12516,6 +13767,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12526,6 +13778,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -12536,6 +13789,7 @@
     "Forces": "orch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "Bach's authorship uncertain"
   },
@@ -12546,6 +13800,7 @@
     "Forces": "orch",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "—",
     "Notes": "see BWV 1046a"
   },
@@ -12556,6 +13811,7 @@
     "Forces": "8vv",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12566,6 +13822,7 @@
     "Forces": "4open",
     "Key": "A minor",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12576,6 +13833,7 @@
     "Forces": "4open",
     "Key": "A minor",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12586,6 +13844,7 @@
     "Forces": "2open",
     "Key": "D major",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12596,6 +13855,7 @@
     "Forces": "4open",
     "Key": "G major",
     "Date": "1746",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12606,6 +13866,7 @@
     "Forces": "3open",
     "Key": "G major",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12616,6 +13877,7 @@
     "Forces": "7open",
     "Key": "F major",
     "Date": "1749",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12626,6 +13888,7 @@
     "Forces": "fl hpd 2vn",
     "Key": "",
     "Date": "1747",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12636,6 +13899,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1748–49",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "incomplete"
   },
@@ -12646,6 +13910,7 @@
     "Forces": "ch bc",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "chorale for aMissa brevisbyGiovanni Battista Bassani"
   },
@@ -12656,6 +13921,7 @@
     "Forces": "ch str bc",
     "Key": "E minor",
     "Date": "1740–42",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "arr. of the 3rd movt. of the Magnificat in C major byAntonio Caldara"
   },
@@ -12666,6 +13932,7 @@
     "Forces": "2vv str bc",
     "Key": "",
     "Date": "1745–47",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "adaptation of theStabat MaterbyGiovanni Battista Pergolesi"
   },
@@ -12676,6 +13943,7 @@
     "Forces": "ch vn 2va bc",
     "Key": "D minor",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -12686,6 +13954,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1715–18?",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12696,6 +13965,7 @@
     "Forces": "2open",
     "Key": "D major",
     "Date": "1750?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": ""
   },
@@ -12706,6 +13976,7 @@
     "Forces": "6open",
     "Key": "G major",
     "Date": "1747–48",
+    "City": "Leipzig",
     "Genre": "Chamber",
     "Notes": "based on the theme of BWV 988"
   },
@@ -12716,6 +13987,7 @@
     "Forces": "v 2bn/2vc bc",
     "Key": "G minor/ E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "intended for thePassions-PasticciobyKarl Heinrich Graun; Bach's authorship uncertain"
   },
@@ -12726,6 +13998,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -12736,6 +14009,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12746,6 +14020,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12756,6 +14031,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12766,6 +14042,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12776,6 +14053,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12786,6 +14064,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12796,6 +14075,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12806,6 +14086,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "also attributed toJohann Pachelbel"
   },
@@ -12816,6 +14097,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12826,6 +14108,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12836,6 +14119,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12846,6 +14130,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12856,6 +14141,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12866,6 +14152,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12876,6 +14163,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12886,6 +14174,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12896,6 +14185,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12906,6 +14196,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12916,6 +14207,7 @@
     "Forces": "org",
     "Key": "D major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12926,6 +14218,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12936,6 +14229,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12946,6 +14240,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12956,6 +14251,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12966,6 +14262,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12976,6 +14273,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12986,6 +14284,7 @@
     "Forces": "org",
     "Key": "F minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -12996,6 +14295,7 @@
     "Forces": "org",
     "Key": "C major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13006,6 +14306,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13016,6 +14317,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13026,6 +14328,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13036,6 +14339,7 @@
     "Forces": "org",
     "Key": "D minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13046,6 +14350,7 @@
     "Forces": "org",
     "Key": "E minor",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13056,6 +14361,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1706–10",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "formerly BWV Anh.205"
   },
@@ -13066,6 +14372,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1703–07?",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13076,6 +14383,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13086,6 +14394,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13096,6 +14405,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13106,6 +14416,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13116,6 +14427,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": ""
   },
@@ -13126,6 +14438,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1713",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -13136,6 +14449,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "formerly BWV Anh.71"
   },
@@ -13146,6 +14460,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Text",
     "Notes": "Regula Joh. Seb. Bachii"
   },
@@ -13156,6 +14471,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1742-43",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": "Canones aliquot per Josephum Zarlinum"
   },
@@ -13166,6 +14482,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1743-46",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": ""
   },
@@ -13176,6 +14493,7 @@
     "Forces": "—",
     "Key": "",
     "Date": "1743-46",
+    "City": "Leipzig",
     "Genre": "—",
     "Notes": ""
   },
@@ -13186,6 +14504,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1740-45",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": "Basso continuo rules (Generalbassregeln I)"
   },
@@ -13196,6 +14515,7 @@
     "Forces": "text",
     "Key": "",
     "Date": "1738?",
+    "City": "Leipzig",
     "Genre": "Text",
     "Notes": "Basso continuo rules (Generalbassregeln II)"
   },
@@ -13206,6 +14526,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.199.Cantata for the Feast of the Annunciation; lost"
   },
@@ -13216,6 +14537,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1714-17",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.209."
   },
@@ -13226,6 +14548,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1709",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.192. 2nd Cantata for the inauguration of Mühlhausen town council; lost"
   },
@@ -13236,6 +14559,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1710",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "3rd Cantata for the inauguration of Mühlhausen town council; lost"
   },
@@ -13246,6 +14570,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.192. Cantata for the inauguration of Leipzig town council; 1st version of BWV 1139a; music lost"
   },
@@ -13256,6 +14581,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.4a. Cantata for the 3rd day of the 200th anniversary of the Augsburg Confession; 2nd version of BWV 1139; music lost"
   },
@@ -13266,6 +14592,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.3. Cantata for the inauguration of Leipzig town council; music lost"
   },
@@ -13276,6 +14603,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.193. cantata for the inauguration of Leipzig town council; last chorus based on BWV 208, otherwise lost"
   },
@@ -13286,6 +14614,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1716",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "cantata for the memorial service for Prince Johann Ernst of Saxe-Weimar, otherwise lost"
   },
@@ -13296,6 +14625,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 244a. Partly based on BWV 198, BWV 247, BWV 244b; lost"
   },
@@ -13306,6 +14636,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.14. Wedding cantata for Christoph Friedrich Lösner and Johanna Elisabetha Scherling; music lost"
   },
@@ -13316,6 +14647,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.211. Cantata for the wedding of the lawyer and university professor Johann Friedrich Höckner with Jacobina Agnetha Bartholomäus, otherwise music lost"
   },
@@ -13326,6 +14658,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.212. Cantata for the wedding of the merchant Christoph Georg Winckler with Caroline Wilhelmine Jöcher, otherwise music lost"
   },
@@ -13336,6 +14669,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.5. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13346,6 +14680,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "1724?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.15. Cantata for a degree ceremony at Leipzig University; fragment only"
   },
@@ -13356,6 +14691,7 @@
     "Forces": "5vv orch",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "arrangement of the motet \"Tristis est anima mea\" probably byJohann Kuhnau"
   },
@@ -13366,6 +14702,7 @@
     "Forces": "bass orch",
     "Key": "",
     "Date": "1721-22",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.197. Cantata as a tribute music in honor of the princely house of Anhalt-Köthen or was for New Year's Day; lost"
   },
@@ -13376,6 +14713,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1719",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.6. Cantata for New Year's Day; music lost"
   },
@@ -13386,6 +14724,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.8. Cantata for New Year's Day; lost; possibly the same as BWV 184a"
   },
@@ -13396,6 +14735,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.7. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13406,6 +14746,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.194. Cantata for the birthday of Johann August of Anhalt-Zerbst; lost"
   },
@@ -13416,6 +14757,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.20. Cantata (ode) for the birthday of Duke Friedrich II of Saxe-Gotha; music lost"
   },
@@ -13426,6 +14768,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.9. Cantata for birthday of King August III; music lost"
   },
@@ -13436,6 +14779,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.11. Cantata for the nameday of King August II of Poland; music lost"
   },
@@ -13446,6 +14790,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.12. Cantata for the nameday of King August III of Poland; based on BWV Anh.18; music lost"
   },
@@ -13456,6 +14801,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1739",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the birthday of King August III of Poland; libretto and music lost"
   },
@@ -13466,6 +14812,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.10. Cantata for the birthday of Joachim Friedrich Reichsgraf von Flemming; music lost"
   },
@@ -13476,6 +14823,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.13. Cantata for the wedding of Prince Carl IV and Princess Maria Amalia; music lost"
   },
@@ -13486,6 +14834,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.18. Cantata for occasion of the rededication of the rebuilt St. Thomas School; music lost; rev. as BWV Anh.12"
   },
@@ -13496,6 +14845,7 @@
     "Forces": "4vv ch orch?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "formally BWV Anh.196. Cantata on the occasion of the wedding of Peter Hohman the Younger; music lost"
   },
@@ -13506,6 +14856,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1731-32",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "music lost"
   },
@@ -13516,6 +14867,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "1713?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "formerly BWV Anh.159. Attributed toJohann Christoph Bach"
   },
@@ -13526,6 +14878,7 @@
     "Forces": "4vv ch orch",
     "Key": "",
     "Date": "1713?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": ""
   },
@@ -13536,6 +14889,7 @@
     "Forces": "5vv orch",
     "Key": "",
     "Date": "1735-50",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "is based onKarl Heinrich Graun's Passion cantata \"Ein Lämmlein geht und tragen die Schuld\" (so-called \"Kleine Passion\" (GraunWV B:VII:4), Braunschweig before 1735) withGeorg Philipp Telemann's opening chorus, \"Wer ist der, so von Edom kömmt\" TVWV 1:1585 (from the Palmarum cantata of the French vintage), and the following chorale movement for \"Christus, der uns selig macht\" (from D to E transposed final chorale of the same cantata); the following movements (3rd–18th) are all by Graun."
   },
@@ -13546,6 +14900,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.213. Arrangement of a concerto byGeorg Philipp Telemann"
   },
@@ -13556,6 +14911,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.200. Incomplete"
   },
@@ -13566,6 +14922,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1714–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.55. Bach's authorship uncertain"
   },
@@ -13576,6 +14933,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13586,6 +14944,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13596,6 +14955,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13606,6 +14966,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13616,6 +14977,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13626,6 +14988,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "formally BWV Anh.77. Bach's authorship uncertain"
   },
@@ -13636,6 +14999,7 @@
     "Forces": "orch",
     "Key": "D major",
     "Date": "1726",
+    "City": "Leipzig",
     "Genre": "Orchestral",
     "Notes": ""
   },
@@ -13646,6 +15010,7 @@
     "Forces": "vv 2fl str bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:617)"
   },
@@ -13656,6 +15021,7 @@
     "Forces": "4vv ch str bc",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the 19th Sunday after Trinity; fragment only"
   },
@@ -13666,6 +15032,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1140. Cantata for the inauguration of Leipzig town council; music lost"
   },
@@ -13676,6 +15043,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1139. Cantata for the inauguration of Leipzig town council; 1st version of BWV Anh.4a; music lost"
   },
@@ -13686,6 +15054,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1730",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1139a. Cantata for the 3rd day of the 200th anniversary of the Augsburg Confession; 2nd version of BWV Anh.4; music lost"
   },
@@ -13696,6 +15065,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1718",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1147. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13706,6 +15076,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1719",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1151. Cantata for New Year's Day; music lost"
   },
@@ -13716,6 +15087,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1720",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1153. Cantata for the birthday of Prince Leopold of Anhalt-Cöthen; music lost"
   },
@@ -13726,6 +15098,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1152. Cantata for New Year's Day; lost; possibly the same as BWV 184a"
   },
@@ -13736,6 +15109,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1727",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1156. Cantata for birthday of King August III; music lost"
   },
@@ -13746,6 +15120,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1731",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1160. Cantata for the birthday of Joachim Friedrich Reichsgraf von Flemming; music lost"
   },
@@ -13756,6 +15131,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1157. Cantata for the nameday of King August II of Poland; music lost"
   },
@@ -13766,6 +15142,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1733",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1158. Cantata for the nameday of King August III of Poland; based on BWV Anh.18; music lost"
   },
@@ -13776,6 +15153,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1738",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1161. Cantata for the wedding of Prince Carl IV and Princess Maria Amalia; music lost"
   },
@@ -13786,6 +15164,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1144. Wedding cantata for Christoph Friedrich Lösner and Johanna Elisabetha Scherling; music lost"
   },
@@ -13796,6 +15175,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "1724?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1148. Cantata for a degree ceremony at Leipzig University; fragment only"
   },
@@ -13806,6 +15186,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1735",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "funeral cantata; music lost"
   },
@@ -13816,6 +15197,7 @@
     "Forces": "4vv orch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "funeral cantata; fragments only"
   },
@@ -13826,6 +15208,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1732",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1162. Cantata for occasion of the rededication of the rebuilt St. Thomas School; music lost; rev. as BWV Anh.12"
   },
@@ -13836,6 +15219,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for the Thomasschule in Leipzig; music lost"
   },
@@ -13846,6 +15230,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1155. Cantata (ode) for the birthday of Duke Friedrich II of Saxe-Gotha; music lost"
   },
@@ -13856,6 +15241,7 @@
     "Forces": "v fl str bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byMelchior Hoffmann"
   },
@@ -13866,6 +15252,7 @@
     "Forces": "ob vb orch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "lost, only the theme remains"
   },
@@ -13876,6 +15263,7 @@
     "Forces": "str bc",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "bc part only; spurious; composed byTomaso Albinoni"
   },
@@ -13886,6 +15274,7 @@
     "Forces": "ch str bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christoph Pez"
   },
@@ -13896,6 +15285,7 @@
     "Forces": "ch orch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13906,6 +15296,7 @@
     "Forces": "ch orch",
     "Key": "C minor",
     "Date": "1727–32",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "spurious; composed byFrancesco Durante, butChriste eleisonadapted by Bach as BWV 242"
   },
@@ -13916,6 +15307,7 @@
     "Forces": "ch orch",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig Krebs)"
   },
@@ -13926,6 +15318,7 @@
     "Forces": "ch orch",
     "Key": "B♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13936,6 +15329,7 @@
     "Forces": "?",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "bass part only; Bach's authorship uncertain"
   },
@@ -13946,6 +15340,7 @@
     "Forces": "2ch orch",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain; possibly composed byAntonio Lotti"
   },
@@ -13956,6 +15351,7 @@
     "Forces": "ch 2tpt",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13966,6 +15362,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13976,6 +15373,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13986,6 +15384,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -13996,6 +15395,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14006,6 +15406,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14016,6 +15417,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14026,6 +15428,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14036,6 +15439,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14046,6 +15450,7 @@
     "Forces": "v bc",
     "Key": "",
     "Date": "1704?",
+    "City": "Arnstadt",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14056,6 +15461,7 @@
     "Forces": "kbd (or voice, keyboard)",
     "Key": "",
     "Date": "1734?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14066,6 +15472,7 @@
     "Forces": "kbd (or voice, keyboard)",
     "Key": "",
     "Date": "1734?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14076,6 +15483,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14086,6 +15494,7 @@
     "Forces": "org",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.233, H.776)"
   },
@@ -14096,6 +15505,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Peter KellnerorJohann Christoph Kellner"
   },
@@ -14106,6 +15516,7 @@
     "Forces": "org",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJustin Heinrich Knecht"
   },
@@ -14116,6 +15527,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Tobias Krebs"
   },
@@ -14126,6 +15538,7 @@
     "Forces": "org",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Peter Kellner"
   },
@@ -14136,6 +15549,7 @@
     "Forces": "org",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14146,6 +15560,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Gottfried Walther"
   },
@@ -14156,6 +15571,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14166,6 +15582,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14176,6 +15593,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14186,6 +15604,7 @@
     "Forces": "v bells str bc",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain; possibly composed byMelchior Hoffmann"
   },
@@ -14196,6 +15615,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14206,6 +15626,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1714–17",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see BWV 1170. Bach's authorship uncertain"
   },
@@ -14216,6 +15637,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Philipp Telemann"
   },
@@ -14226,6 +15648,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed by Johann Caspar Vogler"
   },
@@ -14236,6 +15659,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14246,6 +15670,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14256,6 +15681,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Gottfried Walther"
   },
@@ -14266,6 +15692,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Pachelbel"
   },
@@ -14276,6 +15703,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14286,6 +15714,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14296,6 +15725,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14306,6 +15736,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14316,6 +15747,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14326,6 +15758,7 @@
     "Forces": "tpt org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14336,6 +15769,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14346,6 +15780,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14356,6 +15791,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14366,6 +15802,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14376,6 +15813,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "see BWV 1128"
   },
@@ -14386,6 +15824,7 @@
     "Forces": "org",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14396,6 +15835,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
   },
@@ -14406,6 +15846,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGottfried August Homilius; see also BWV 759"
   },
@@ -14416,6 +15857,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14426,6 +15868,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14436,6 +15879,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "1718?",
+    "City": "Köthen",
     "Genre": "Keyboard",
     "Notes": "see BWV 1176. Bach's authorship uncertain"
   },
@@ -14446,6 +15890,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14456,6 +15901,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14466,6 +15912,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14476,6 +15923,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "incomplete; Bach's authorship uncertain"
   },
@@ -14486,6 +15934,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Bernhard Bach"
   },
@@ -14496,6 +15945,7 @@
     "Forces": "kbd",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Bernhard Bach"
   },
@@ -14506,6 +15956,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Bernhard Bach"
   },
@@ -14516,6 +15967,7 @@
     "Forces": "kbd",
     "Key": "F minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14526,6 +15978,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14536,6 +15989,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14546,6 +16000,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Christoph Kellner"
   },
@@ -14556,6 +16011,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14566,6 +16022,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger; formerly attributed toCarl Philipp Emanuel Bachas H.388"
   },
@@ -14576,6 +16033,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14586,6 +16044,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14596,6 +16055,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14606,6 +16066,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger"
   },
@@ -14616,6 +16077,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14626,6 +16088,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14636,6 +16099,7 @@
     "Forces": "kbd",
     "Key": "F♯major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -14646,6 +16110,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
   },
@@ -14656,6 +16121,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
   },
@@ -14666,6 +16132,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.373.5)"
   },
@@ -14676,6 +16143,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14686,6 +16154,7 @@
     "Forces": "kbd",
     "Key": "G♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14696,6 +16165,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14706,6 +16176,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14716,6 +16187,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14726,6 +16198,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorge Frideric Handel"
   },
@@ -14736,6 +16209,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Andreas Sorge"
   },
@@ -14746,6 +16220,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byGeorg Andreas SorgeorCarl Philipp Emanuel Bach"
   },
@@ -14756,6 +16231,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14766,6 +16242,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; probably composed byGeorg Andreas Sorge"
   },
@@ -14776,6 +16253,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14786,6 +16264,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Philipp Kirnberger"
   },
@@ -14796,6 +16275,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "20 doubtful or spurious piees"
   },
@@ -14806,6 +16286,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14816,6 +16297,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristian Pezold"
   },
@@ -14826,6 +16308,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristian Pezold"
   },
@@ -14836,6 +16319,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14846,6 +16330,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; see also BWV Anh.117b; Bach's authorship uncertain"
   },
@@ -14856,6 +16341,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "alternate version of BWV Anh.117a; Bach's authorship uncertain"
   },
@@ -14866,6 +16352,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14876,6 +16363,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byCarl Philipp Emanuel Bach"
   },
@@ -14886,6 +16374,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14896,6 +16385,7 @@
     "Forces": "kbd",
     "Key": "C minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14906,6 +16396,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/1)"
   },
@@ -14916,6 +16407,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/2)"
   },
@@ -14926,6 +16418,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/3)"
   },
@@ -14936,6 +16429,7 @@
     "Forces": "kbd",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.1/4)"
   },
@@ -14946,6 +16440,7 @@
     "Forces": "kbd",
     "Key": "D major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14956,6 +16451,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "spurious"
   },
@@ -14966,6 +16462,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -14976,6 +16473,7 @@
     "Forces": "hpd",
     "Key": "E♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.65/7, H.16)"
   },
@@ -14986,6 +16484,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Adolph Hasse"
   },
@@ -14996,6 +16495,7 @@
     "Forces": "kbd",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Christian Bach(W.A22); incomplete"
   },
@@ -15006,6 +16506,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15016,6 +16517,7 @@
     "Forces": "morg",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.207)"
   },
@@ -15026,6 +16528,7 @@
     "Forces": "kbd",
     "Key": "C major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15036,6 +16539,7 @@
     "Forces": "kbd",
     "Key": "G major",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15046,6 +16550,7 @@
     "Forces": "vn bc",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15056,6 +16561,7 @@
     "Forces": "vn kbd",
     "Key": "E♭major",
     "Date": "?",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15066,6 +16572,7 @@
     "Forces": "str bc kbd",
     "Key": "A major",
     "Date": "?",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15076,6 +16583,7 @@
     "Forces": "ch str bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:732)"
   },
@@ -15086,6 +16594,7 @@
     "Forces": "ch orch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 1:836)"
   },
@@ -15096,6 +16605,7 @@
     "Forces": "v fl str bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christian Bach(part of the operaOrione, ossia Diana vendicata, W.G4)"
   },
@@ -15106,6 +16616,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "1713?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "see BWV 1165. Formerly attributed toJohann Christoph Bach"
   },
@@ -15116,6 +16627,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byGeorg Philipp Telemann(TWV 8:10)"
   },
@@ -15126,6 +16638,7 @@
     "Forces": "2ch (strings, continuo?)",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byKarl Heinrich Graun(GraunWV 10)"
   },
@@ -15136,6 +16649,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed by Georg Gottfried Wagner"
   },
@@ -15146,6 +16660,7 @@
     "Forces": "2ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christoph Bach"
   },
@@ -15156,6 +16671,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Christoph Altnikol"
   },
@@ -15166,6 +16682,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ernst Bach"
   },
@@ -15176,6 +16693,7 @@
     "Forces": "ch str bc",
     "Key": "E minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig Bach"
   },
@@ -15186,6 +16704,7 @@
     "Forces": "4vv ch orch",
     "Key": "G major",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Ludwig BachorAntonio Lotti"
   },
@@ -15196,6 +16715,7 @@
     "Forces": "4vv str",
     "Key": "G minor",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.100)"
   },
@@ -15206,6 +16726,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1725?",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "music lost; probably never composed"
   },
@@ -15216,6 +16737,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "spurious; composed byJohann Rosenmüller"
   },
@@ -15226,6 +16748,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Pachelbel"
   },
@@ -15236,6 +16759,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -15246,6 +16770,7 @@
     "Forces": "vn bc",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(Nos.2, 5, 6, 7 from Op.10)"
   },
@@ -15256,6 +16781,7 @@
     "Forces": "vn bc",
     "Key": "B minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.2 from Op.10)"
   },
@@ -15266,6 +16792,7 @@
     "Forces": "vn bc",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.5 from Op.10)"
   },
@@ -15276,6 +16803,7 @@
     "Forces": "vn bc",
     "Key": "C minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.6 from Op.10)"
   },
@@ -15286,6 +16814,7 @@
     "Forces": "vn bc",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byFrancesco Antonio Bonporti(No.7 from Op.10)"
   },
@@ -15296,6 +16825,7 @@
     "Forces": "kbd",
     "Key": "E♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Christoph Bach"
   },
@@ -15306,6 +16836,7 @@
     "Forces": "org",
     "Key": "A major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composer uncertain"
   },
@@ -15316,6 +16847,7 @@
     "Forces": "kbd",
     "Key": "",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann David Heinichen"
   },
@@ -15326,6 +16858,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Peter Kellner"
   },
@@ -15336,6 +16869,7 @@
     "Forces": "kbd",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byJohann Ludwig Krebs"
   },
@@ -15346,6 +16880,7 @@
     "Forces": "kbd",
     "Key": "D minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byChristian Friedrich Witt"
   },
@@ -15356,6 +16891,7 @@
     "Forces": "kbd",
     "Key": "B♭major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "inNotebook II for Anna Magdalena Bach; spurious; composed byFrançois Couperin"
   },
@@ -15366,6 +16902,7 @@
     "Forces": "vn bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarlo Zuccari(Op.1 No.10)"
   },
@@ -15376,6 +16913,7 @@
     "Forces": "2vn bc",
     "Key": "D major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(H.585)"
   },
@@ -15386,6 +16924,7 @@
     "Forces": "2vn bc",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.154, H.576)"
   },
@@ -15396,6 +16935,7 @@
     "Forces": "fl bn vn",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Chamber",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.159, H.587)"
   },
@@ -15406,6 +16946,7 @@
     "Forces": "2hpd",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "spurious; composed byWilhelm Friedemann Bach(F.10)"
   },
@@ -15416,6 +16957,7 @@
     "Forces": "hpd str bc",
     "Key": "A minor",
     "Date": "—",
+    "City": "",
     "Genre": "Orchestral",
     "Notes": "spurious; composed byCarl Philipp Emanuel Bach(Wq.1, H.403)"
   },
@@ -15426,6 +16968,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for Easter Monday; fragment only"
   },
@@ -15436,6 +16979,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1715?",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "lost"
   },
@@ -15446,6 +16990,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1709",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "see BWV 1137. cantata for the inauguration of Mühlhausen town council; lost"
   },
@@ -15456,6 +17001,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1740",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1141. Cantata for the inauguration of Leipzig town council; last chorus based on BWV 208, otherwise lost"
   },
@@ -15466,6 +17012,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1722",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1154. Cantata for the birthday of Johann August of Anhalt-Zerbst; lost"
   },
@@ -15476,6 +17023,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1723",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "cantata for Johann Florens Rivinus; lost"
   },
@@ -15486,6 +17034,7 @@
     "Forces": "4vv ch orch?",
     "Key": "",
     "Date": "1725",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1163. Cantata on the occasion of the wedding of Peter Hohman the Younger; lost"
   },
@@ -15496,6 +17045,7 @@
     "Forces": "bass orch",
     "Key": "",
     "Date": "1721-22",
+    "City": "Köthen",
     "Genre": "Vocal",
     "Notes": "see BWV 1150. Cantata as a tribute music in honor of the princely house of Anhalt-Köthen or was for New Year's Day; lost"
   },
@@ -15506,6 +17056,7 @@
     "Forces": "ch orch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "cantata for the Feast of St. Michael; fragment only"
   },
@@ -15516,6 +17067,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1724",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1135. cantata for the Feast of the Annunciation; lost"
   },
@@ -15526,6 +17078,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "1713–15",
+    "City": "Weimar",
     "Genre": "Keyboard",
     "Notes": "see BWV 1169. Incomplete"
   },
@@ -15536,6 +17089,7 @@
     "Forces": "ch",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15546,6 +17100,7 @@
     "Forces": "ch",
     "Key": "G minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15556,6 +17111,7 @@
     "Forces": "ch",
     "Key": "F major",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15566,6 +17122,7 @@
     "Forces": "ch",
     "Key": "A minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15576,6 +17133,7 @@
     "Forces": "ch",
     "Key": "B minor",
     "Date": "?",
+    "City": "",
     "Genre": "Vocal",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15586,6 +17144,7 @@
     "Forces": "org",
     "Key": "C minor",
     "Date": "1706–10",
+    "City": "Arnstadt",
     "Genre": "Keyboard",
     "Notes": "see BWV 1121."
   },
@@ -15596,6 +17155,7 @@
     "Forces": "org",
     "Key": "",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain"
   },
@@ -15606,6 +17166,7 @@
     "Forces": "kbd",
     "Key": "E minor",
     "Date": "?",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Bach's authorship uncertain; possibly composed byJohann Peter Kellner"
   },
@@ -15616,6 +17177,7 @@
     "Forces": "kbd",
     "Key": "E♭minor",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "Johann Ernst Eberlin"
   },
@@ -15626,6 +17188,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1714-17",
+    "City": "Weimar",
     "Genre": "Vocal",
     "Notes": "see BWV 1136."
   },
@@ -15636,6 +17199,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1734",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "probably never composed. Music for the farewell party for the Thomasschule rector Johann Matthias Gesner, otherwise music lost."
   },
@@ -15646,6 +17210,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1145. Cantata for the wedding of the lawyer and university professor Johann Friedrich Höckner with Jacobina Agnetha Bartholomäus, otherwise music lost"
   },
@@ -15656,6 +17221,7 @@
     "Forces": "?",
     "Key": "",
     "Date": "1729",
+    "City": "Leipzig",
     "Genre": "Vocal",
     "Notes": "see BWV 1146. Cantata for the wedding of the merchant Christoph Georg Winckler with Caroline Wilhelmine Jöcher, otherwise music lost"
   },
@@ -15666,6 +17232,7 @@
     "Forces": "org",
     "Key": "F major",
     "Date": "—",
+    "City": "",
     "Genre": "Keyboard",
     "Notes": "see BWV 1168. Arrangement of a concerto byGeorg Philipp Telemann"
   }


### PR DESCRIPTION
## Summary
- populate `City` field in Bach works datasets using composition-year to city mapping
- show new `Miasto` column in the works table for each composition's city
- note that some works may lack city data when sources are incomplete

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('works.json','utf8'));JSON.parse(fs.readFileSync('bach_works.json','utf8'));console.log('JSON OK')"`


------
https://chatgpt.com/codex/tasks/task_e_689536193fe0832f8acab0eaaa80dada