### PR TITLE
Add interactive timeline for Bach's life

### DIFF
--- a/bach_timeline.html
+++ b/bach_timeline.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Oś czasu życia Johanna Sebastiana Bacha</title>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f5f5f5;
+      padding: 20px;
+      margin: 0;
+    }
+    #timeline svg {
+      background: #fff;
+      border: 1px solid #ccc;
+    }
+    .tooltip {
+      position: absolute;
+      background: #fff;
+      border: 1px solid #ccc;
+      padding: 5px;
+      pointer-events: none;
+      font-size: 0.9em;
+    }
+  </style>
+</head>
+<body>
+  <h1>Oś czasu życia Johanna Sebastiana Bacha</h1>
+  <div id="timeline"></div>
+  <script>
+  fetch('timeline_data.json')
+    .then(response => response.json())
+    .then(data => {
+      const margin = {top: 20, right: 20, bottom: 30, left: 40};
+      const width = 1000 - margin.left - margin.right;
+      const height = 200 - margin.top - margin.bottom;
+
+      const svg = d3.select('#timeline')
+        .append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      const x = d3.scaleLinear()
+        .domain(d3.extent(data, d => d.year))
+        .range([0, width]);
+
+      svg.append('g')
+        .attr('transform', `translate(0,${height})`)
+        .call(d3.axisBottom(x).tickFormat(d3.format('d')));
+
+      const tooltip = d3.select('body')
+        .append('div')
+        .attr('class', 'tooltip')
+        .style('display', 'none');
+
+      svg.selectAll('circle')
+        .data(data)
+        .enter()
+        .append('circle')
+        .attr('cx', d => x(d.year))
+        .attr('cy', height / 2)
+        .attr('r', 4)
+        .attr('fill', 'steelblue')
+        .on('mouseover', (event, d) => {
+          tooltip
+            .style('display', 'block')
+            .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
+            .style('left', (event.pageX + 5) + 'px')
+            .style('top', (event.pageY - 28) + 'px');
+        })
+        .on('mouseout', () => tooltip.style('display', 'none'));
+    });
+  </script>
+</body>
+</html>

--- a/timeline_data.json
+++ b/timeline_data.json
@@ -1,0 +1,392 @@
+[
+  {
+    "year": 1685,
+    "age": "",
+    "event": "Johann Sebastian Bach born, 21 March, at Eisenach. Youngest child of Johann Ambrosius Bach, town and court musician, and his wife Maria Elisabetha, née Lämmerhirt. Baptised, 23 March.",
+    "musicians": "Handel born, 23 Feb D. Scarlatti born, 26 Oct. Albinoni aged 14 Biber 41 Blow 36 Böhm 24 G. Bononcini 15 Buxtehude 48 Caldara c. 15 Charpentier c40 Corelli 32 Couperin 17 Fux 25 Graupner 2 Heinichen 2 Keiser 11 Kerll 58 J.P. Krieger 36 Kuhnau 25 Lalande 28 Legrenzi 59 Lully 53 A. Marcello 1 Marchand 16 Mattheson 4 Pachelbel 32 Pasquini 48 Purcell 26 Rameau 2 Reincken 62 A. Scarlatti 25 Steffani 31 Telemann 4 Vivaldi 7 J.G. Walther 1 Zelenka 6."
+  },
+  {
+    "year": 1686,
+    "age": "1",
+    "event": "",
+    "musicians": "B. Marcello born, 24 July or 1 Aug Porpora born, 17 Aug. Sylvius Leopold Weiss born, 21 Oct."
+  },
+  {
+    "year": 1687,
+    "age": "2",
+    "event": "",
+    "musicians": "Geminiani bapt. 5 Dec Lully (54) dies, 22 March Pisendel born, 26 Dec."
+  },
+  {
+    "year": 1688,
+    "age": "3",
+    "event": "",
+    "musicians": "Fasch born, 15 April."
+  },
+  {
+    "year": 1689,
+    "age": "4",
+    "event": "",
+    "musicians": "Boismortier born, 23 Dec."
+  },
+  {
+    "year": 1690,
+    "age": "5",
+    "event": "",
+    "musicians": "Legrenzi (63) dies, 17 May"
+  },
+  {
+    "year": 1691,
+    "age": "6",
+    "event": "",
+    "musicians": "1692 7 Enters Lateinschule, Eisenach. Tartini born, 8 April."
+  },
+  {
+    "year": 1693,
+    "age": "8",
+    "event": "",
+    "musicians": "Kerll (65) dies, 13 Feb."
+  },
+  {
+    "year": 1694,
+    "age": "9",
+    "event": "Mother (50) dies, 1 May.",
+    "musicians": ""
+  },
+  {
+    "year": 1695,
+    "age": "10",
+    "event": "Father (49) dies, 20 Feb. Bach leaves Eisenach to live with brother, Johann Christoph (24), in Ohrdruf. Enters lyceum there.",
+    "musicians": "Locatelii born, 3 Sept. Purcell (36) dies, 21 Nov."
+  },
+  {
+    "year": 1696,
+    "age": "11",
+    "event": "",
+    "musicians": ""
+  },
+  {
+    "year": 1697,
+    "age": "12",
+    "event": "",
+    "musicians": "Leclair born, 10 May Quantz born, 30 Jan."
+  },
+  {
+    "year": 1698,
+    "age": "13",
+    "event": "",
+    "musicians": ""
+  },
+  {
+    "year": 1699,
+    "age": "14",
+    "event": "",
+    "musicians": "Hasse bapt. 25 March"
+  },
+  {
+    "year": 1700,
+    "age": "15",
+    "event": "Leaves Ohrdruf for Lüneburg. Enrols in Michaelisschule there.",
+    "musicians": "B.G. Sammartini born (or 1701)"
+  },
+  {
+    "year": 1701,
+    "age": "16",
+    "event": "",
+    "musicians": ""
+  },
+  {
+    "year": 1702,
+    "age": "17",
+    "event": "Applies unsuccessfully for organist's post at Jakobirche, Sangerhausen",
+    "musicians": ""
+  },
+  {
+    "year": 1703,
+    "age": "18",
+    "event": "Court musician at Weimar, March-Sept. Appointed organist at Neuekirche, Arnstadt, 9 Aug.",
+    "musicians": "C.H. Graun born (or 1704) Harrer born, 8 May"
+  },
+  {
+    "year": 1704,
+    "age": "19",
+    "event": "",
+    "musicians": "Biber (59) dies, 3 May Charpentier (c.59) dies, 24 Feb."
+  },
+  {
+    "year": 1705,
+    "age": "20",
+    "event": "Granted 4 weeks leave of absence to visit Lübeck in ?Oct, but stays away longer.",
+    "musicians": ""
+  },
+  {
+    "year": 1706,
+    "age": "21",
+    "event": "Returns to Arnstadt, Jan/Feb. Appears before the consistory to answer for length of absence.",
+    "musicians": "Martini born, 24 April Pachelbel (52) buried, 9 March"
+  },
+  {
+    "year": 1707,
+    "age": "22",
+    "event": "Appointed organist at Blasiuskirche, Mühlhausen, 15 June. Marries Marie Barbara Bach (23) at Dornheim, 17 Oct.",
+    "musicians": "Buxtehude (c.70) dies, 1 Oct."
+  },
+  {
+    "year": 1708,
+    "age": "23",
+    "event": "Appointed organist and chamber musician to Duke Wilhelm Ernst at Weimar, June. First child, Catharina Dorotheo, bapt. 29 Dec.",
+    "musicians": "Blow (59) dies, 1 Oct."
+  },
+  {
+    "year": 1709,
+    "age": "24",
+    "event": "",
+    "musicians": "F. Benda bapt., 22 Nov."
+  },
+  {
+    "year": 1710,
+    "age": "25",
+    "event": "Second child, Wilhelm Friedemann, born, 22 Nov.",
+    "musicians": "Arne bapt., 28 May Pasquini (72) dies, 21 Nov. Pergolesi born, 4 Jan."
+  },
+  {
+    "year": 1711,
+    "age": "26",
+    "event": "",
+    "musicians": "Boyce born, Sept."
+  },
+  {
+    "year": 1712,
+    "age": "27",
+    "event": "",
+    "musicians": ""
+  },
+  {
+    "year": 1713,
+    "age": "28",
+    "event": "Visits Weissenfels, Feb. Third and fourth children (twins), Johann Christoph and Maria Sophia, born 23 Feb, and die, 23 Feb and c.13 March. Bach competes for organist's post at Halle, Dec.",
+    "musicians": "Corelli (59) dies, 8 Jan J.L. Krebs bapt., 12 Oct."
+  },
+  {
+    "year": 1714,
+    "age": "29",
+    "event": "Declines offer of Halle post, Feb, and is promoted to Konzertmeister at Weimar, 2 March. Fifth child, Carl Philipp Emanuel, born, 8 March.",
+    "musicians": "Gluck born, 2 July Jommelli born, 10 Sept."
+  },
+  {
+    "year": 1715,
+    "age": "30",
+    "event": "Sixth child, Johann Gottfried Berhard, born, 11 May.",
+    "musicians": "Doles born, 23 April Wagenseil born, 29 Jan."
+  },
+  {
+    "year": 1716,
+    "age": "31",
+    "event": "Examines new organs at Liebfrauenkirche, Halle, 29 April - 2 May, and Augustinerkirche, Erfurt, July.",
+    "musicians": ""
+  },
+  {
+    "year": 1717,
+    "age": "32",
+    "event": "Appointed Kapellmeister to Prince Leopold at Cöthen, 5 Aug., but is at first prevented by Duke Wilhelm Ernst from taking up the post. Visits Dresden and accepts invitation to take part in contest with Marchand. Is imprisoned by Wilhelm Ernst, 6 Nov., but then allowed to leave Weimar, 2 Dec. Examines organ in Paulinerkirche, Leipzig, 16 Dec.",
+    "musicians": "J. Stamitz bapt., 19 June."
+  },
+  {
+    "year": 1718,
+    "age": "33",
+    "event": "Visits Karlsbad with Prince Leopold, May-June. Seventh child, Leopold Augustus, born, 15 Nov.",
+    "musicians": ""
+  },
+  {
+    "year": 1719,
+    "age": "34",
+    "event": "Death of son, Leopold Augustus (10 months); buried, 29 Sept.",
+    "musicians": "L. Mozart born, 14 Nov."
+  },
+  {
+    "year": 1720,
+    "age": "35",
+    "event": "Visits Karlsbad, May-July. Wife (35) dies; buried 7 July. Bach visits Hamburg, Nov., and is offered post as organist at the Jakobikirche, which he declines.",
+    "musicians": "J.F. Agricola born, 4 Jan. Altnikol bapt., 1 Jan."
+  },
+  {
+    "year": 1721,
+    "age": "36",
+    "event": "Brandenburg Concertos dedicated to Margrave Christian Ludwig, 24 March. Marries Anna Magdalena Wilcke (20) at Cöthen, 3 Dec. Prince Leopold (27) marries Frederica Henrietta von Anhalt-Bernburg (19) at Bernburg, 11 Dec.",
+    "musicians": "Kirnberger born, 24 April."
+  },
+  {
+    "year": 1722,
+    "age": "37",
+    "event": "Brother, Johann Jacob (40) dies, 16 April. Bach enters candidature for cantorate at Leipzig, Dec.",
+    "musicians": "G. Benda bapt., 30 June Kuhnau (62) dies, 5 June Reincken (99) dies, 24 Nov."
+  },
+  {
+    "year": 1723,
+    "age": "38",
+    "event": "Eighth child, Christina Sophia Henrietta, born. Bach signs contract as Thomaskantor in Leipzig, 5 May. Arrives in Leipzig with family, 22 May. Cantata 75 performed in Nikolaikirche, 30 May. Exaines organ at Störmthal, Nov. Magnificat (BWV243a) performed in Thomaskirche, 25 Dec.",
+    "musicians": "Gassmann born, 3 May."
+  },
+  {
+    "year": 1724,
+    "age": "39",
+    "event": "Ninth child, Gottfried Heinrich, born, 26 Feb. St. John Passion performed in Nikolaikirche, 7 April. Examines organ in Johanniskirche, Gera, 25 June.",
+    "musicians": ""
+  },
+  {
+    "year": 1725,
+    "age": "40",
+    "event": "Tenth child, Christian Gottlieb, bapt., 14 April. Bach gives organ recitals in Sophienirche, Dresden, 19-20 Sept. Visits Cöthen, 15 Dec.",
+    "musicians": "J.P. Krieger (75) dies, 6 Feb A. Scarlatti (65) dies, 22 Oct."
+  },
+  {
+    "year": 1726,
+    "age": "41",
+    "event": "Eleventh child, Elisabeth Juliana Friederika, bapt., 5 April. Daughter, Christiana Sophia Henrietta (3) dies, 29 June. Partita I (BWV 825) published, Michaelmas.",
+    "musicians": "Lalande (68) dies, 18 June."
+  },
+  {
+    "year": 1727,
+    "age": "42",
+    "event": "St. Mathew Passion performed in Thomaskirche, 11 April (?). Trauer Ode (BWV 198) performed, 17 Oct, at memorial ceremony for Electress Christiane Eberhardine (died, 4 Sept.). Bach's twelfth child, Ernestus Andreas, bapt., 30 Oct. dies, 1 Nov.",
+    "musicians": "Traetta born, 30 March."
+  },
+  {
+    "year": 1728,
+    "age": "43",
+    "event": "Son, Christian Gottlieb (3), dies, 21 Sept. Thirteenth child, Regina Johanna, bapt., 10 Oct. Prince Leopold of Anhalt-Cöthen (33) dies, 19 Nov. Bach's sister, Marie Salome Wiegand (née Bach) (51), dies in Erfurt, buried 27 Dec.",
+    "musicians": "Piccinni born, 16 Jan Steffani (73) dies, 12 Feb."
+  },
+  {
+    "year": 1729,
+    "age": "44",
+    "event": "Bach visits Weissenfels, Feb. Visits Cöthen to perform funeral music for Prince Leopld, 23-4 March. St. Matthew Passion performed (for second? time) in Thomaskirche, 15 April. Disputes with council over admission of unmusical pupils to Thomasschule. Bach assumes direction of collegium musicum. Illness prevents his visiting Handel in Halle, June. Rektor of Thomasschule, J.H. Ernesti (77) dies, 16 Oct.",
+    "musicians": "Heinichen (46) dies, 16 July."
+  },
+  {
+    "year": 1730,
+    "age": "45",
+    "event": "Fourteenth child, Christiana Benedicta Louise, baptised, 1 Jan.; dies, 4 Jan.; Bach addresses memorandum on church music to town council, 23 Aug., and letter to Erdmann seeking possible employment in Gdansk, 28 Oct.. J.M. Gesner appointed Rektor of the Thomasschule, 8 Sept..",
+    "musicians": ""
+  },
+  {
+    "year": 1731,
+    "age": "46",
+    "event": "Clavier-Übung I (BWV825-30) published. Fifteenth child, Christiana Dorothea, baptised, 18 March. St Mark Passion performed in Thomaskirche, 23 March. Bach gives organ recitals in Dresden, 14-21 Sept. Examines organ at Stöntzsch, 12 Nov.",
+    "musicians": "Cannabich bapt., 28 Dec."
+  },
+  {
+    "year": 1732,
+    "age": "47",
+    "event": "Sixteenth child, Johann Christoph Friedrich, born 21 June. Daughter, Christiana Dorothea (1), dies, 31 Aug. Bach examines organ in Martinskirche, Kassel, 22-8 Sept.",
+    "musicians": "Haydn born, 31 March; Marchand (63) dies, 17 Feb."
+  },
+  {
+    "year": 1733,
+    "age": "48",
+    "event": "Daughter, Regina Johanna (4), dies 25 April. Son, Wilhelm Friedemann (23), appointed organist at Sophienkirche, Dresden, 23 June. Bach visits Dresden, July, and presents Missa (BWV232) to the Elector Friedrich August II. Seventeenth child, Johann August Abraham, bapt., 5 Nov; dies, 6 Nov.",
+    "musicians": "Böhm (71) dies, 18 May; Couperin (64) dies, 11 Sept."
+  },
+  {
+    "year": 1734,
+    "age": "49",
+    "event": "J.A. Ernesti (27) appointed Rektor of the Thomasschule. Christmas Oratorio , parts I-III performed 25, 26, 27 Dec.",
+    "musicians": "Gossec born, 17 Jan."
+  },
+  {
+    "year": 1735,
+    "age": "50",
+    "event": "Christmas Oratoria , parts IV-VI performed, 1, 2, 6 Jan. Clavier-Übung II (BWV971, 831) published, May. Bach examines organ in Marienkirche, Mülhausen, June, where his son Gottfried Bernhard (20) is appointed organist, 16 June. Bach's eighteenth child, Johann Christian, born, 5 Sept.",
+    "musicians": ""
+  },
+  {
+    "year": 1736,
+    "age": "51",
+    "event": "'Battle of the prefects' with Ernesti begins, July. Appointed Hofcompositeur to the Elector of Saxony, 19 Nov. Gives organ recital in Frauenkirche, Dresden, 1 Dec.",
+    "musicians": "Caldar (c.66) dies, 28 Dec; Pergolesi (26) dies, 16 March."
+  },
+  {
+    "year": 1737,
+    "age": "52",
+    "event": "Son, Johann Gottfried Bernhard (22), appointed organist at the Jakobikirche, Sangerhausen, 4 April. Bach temporarily relinquishes directorship of the collegium musicum, Spring. J.A. Schiebe publishes adverse criticism of Bach's music. Johann Elias Bach joins Bach's household as tutor and secretary, ?Oct. Nineteenth child, Johanna Carolina, bapt., 30 Oct.",
+    "musicians": "Myslivecek born, 9 March."
+  },
+  {
+    "year": 1738,
+    "age": "53",
+    "event": "Son, Carl Philipp Emanuel (24), appointed harpsichordist to crown prince Frederick of Prussia. Bach visits Dresden, May. Son, Johann Gottfried Bernhard (23) contracts debts at Sangerhausen and absconds.",
+    "musicians": ""
+  },
+  {
+    "year": 1739,
+    "age": "54",
+    "event": "Son, Johann Gottfried Bernhard (24), dies, 27 May. Bach gives organ recital in the Schlosskirche, Altenburg. Clavier-Übung III published, Sept. Resumes as director of the collegium musicum, 2 Oct. Visits Weissenfels with Anna Magdalena, 7-14 Nov.",
+    "musicians": "Dittersdorf born, 2 Nov.; Keiser (65) dies, 12 Sept; B. Marcello (52/53) dies, 24/25 July; Vanhal born, 12 May."
+  },
+  {
+    "year": 1740,
+    "age": "55",
+    "event": "Visits Halle, April.",
+    "musicians": "Paisiello born, 9 May."
+  },
+  {
+    "year": 1741,
+    "age": "56",
+    "event": "Visits son, Carl Philipp Emanuel, in Berlin, Aug. Anna Magdalena seriously ill. Bach visits Dresden, Nov. Clavier-Übung IV published (or 1742).",
+    "musicians": "Fux (c.80) dies, 13 Feb.; Grétry born, 8 Feb.; Vivaldi (63) dies, 28 July."
+  },
+  {
+    "year": 1742,
+    "age": "57",
+    "event": "Twentieth child, Regina Susanna, bapt., 22 Feb. Johann Elias Bach leaves Leipzig, 31 Oct.",
+    "musicians": ""
+  },
+  {
+    "year": 1743,
+    "age": "58",
+    "event": "Examines organ in Johanniskirche, Leipzig, Dec.",
+    "musicians": "Boccherini born, 19 Feb."
+  },
+  {
+    "year": 1744,
+    "age": "59",
+    "event": "Son, Carl Philipp Emanuel (30), marries Johanna Maria Dannemann (20) in Berlin.",
+    "musicians": ""
+  },
+  {
+    "year": 1745,
+    "age": "60",
+    "event": "First grandchild, Johann August Bach, born, 10 Dec.",
+    "musicians": "Zelenka (66) dies, 22 Dec."
+  },
+  {
+    "year": 1746,
+    "age": "61",
+    "event": "Son, Wilhelm Friedemann (36), appointed organist at the Liebfrauenkirche, Halle, 16 April. Bach examines organ in Wenselskirche, Naumburg, 27 Sept.",
+    "musicians": ""
+  },
+  {
+    "year": 1747,
+    "age": "62",
+    "event": "Visits court of Frederick the Great at Potsdam, 7-8 May, and gives organ recital in teh Heiliggeistkirche there, 8 May. Composes and published (Sept.) the Musical Offering . Joins Mizler's Society of Musical Sciences, June, for which he composes the Canonic Variations (BWV869).",
+    "musicians": "Bononcini (76) dies, 9 July."
+  },
+  {
+    "year": 1748,
+    "age": "63",
+    "event": "",
+    "musicians": "J.G. Walther (63) dies, 23 March."
+  },
+  {
+    "year": 1749,
+    "age": "64",
+    "event": "Daughter, Elisabeth Juliana Frederica (23), marries Johann Christoph Altnikol (29) in Leipzig, 20 Jan. Harrer performs Probe in Leipzig, with a view to succeeding Bach as Thomaskantor, 8 June.",
+    "musicians": "Cimarosa born, 17 Dec."
+  },
+  {
+    "year": 1750,
+    "age": "65",
+    "event": "Son, Johann Christoph Friedrich (18), appointed court musician at Bückeburg, Jan. Bach occupied engraving the Art of Fugue . Operated on by oculist, John Taylor, March-April. Takes final communion, 22 July, and dies, 28 July. Buried in graveyard of the Johanniskirche, 31 July.",
+    "musicians": "A. Marcello (66) dies; Agricola aged 30; Albinoni 79; Altnikol 30; Arne 40; F. Benda 41; G. Benda 28; Boccherini 7; Boismortier 61; Boyce 39; Dittersdorf 11; Doles 35; Fasch 62; Gassmann 27; Geminiani 63; Gluck 36; Gossec 16; C.H. Graun c.47; Graupner 67; Grütry 9; Harrer 47; Hasse 51; Haydn 18; Jommelli 36; Kirnberger 29; J.L. Krebs 37; Leclair 53; Locatelli 55; Martini 44; L. Mozart 31; Myslivecek 13; Paisiello 10; Piccinni 22; Pisendel 63; Porpora 64; Quantz 53; Rameau 67; Sammartini c.50; J. Stamitz 33; Tartini 58; Telemann 69; Traetta 23; Vanhal 11; Wagenseil 35; Weiss 64 (dies)"
+  }
+]


### PR DESCRIPTION
## Summary
- add `timeline_data.json` derived from jsbach.org to record yearly events
- add `bach_timeline.html` using D3 to plot Bach's life timeline with interactive tooltips

## Testing
- `python -m json.tool timeline_data.json`

------
https://chatgpt.com/codex/tasks/task_e_68962e632230832f965bde6b7bcbf6d2