### PR TITLE
Fix offline loading for timeline and map

### DIFF
--- a/bach_timeline.html
+++ b/bach_timeline.html
@@ -28,51 +28,49 @@
 <body>
   <h1>Oś czasu życia Johanna Sebastiana Bacha</h1>
   <div id="timeline"></div>
+  <script id="timeline-data" type="application/json" src="timeline_data.json"></script>
   <script>
-  fetch('timeline_data.json')
-    .then(response => response.json())
-    .then(data => {
-      const margin = {top: 20, right: 20, bottom: 30, left: 40};
-      const width = 1000 - margin.left - margin.right;
-      const height = 200 - margin.top - margin.bottom;
+    const data = JSON.parse(document.getElementById('timeline-data').textContent);
+    const margin = {top: 20, right: 20, bottom: 30, left: 40};
+    const width = 1000 - margin.left - margin.right;
+    const height = 200 - margin.top - margin.bottom;
 
-      const svg = d3.select('#timeline')
-        .append('svg')
-        .attr('width', width + margin.left + margin.right)
-        .attr('height', height + margin.top + margin.bottom)
-        .append('g')
-        .attr('transform', `translate(${margin.left},${margin.top})`);
+    const svg = d3.select('#timeline')
+      .append('svg')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+      .attr('transform', `translate(${margin.left},${margin.top})`);
 
-      const x = d3.scaleLinear()
-        .domain(d3.extent(data, d => d.year))
-        .range([0, width]);
+    const x = d3.scaleLinear()
+      .domain(d3.extent(data, d => d.year))
+      .range([0, width]);
 
-      svg.append('g')
-        .attr('transform', `translate(0,${height})`)
-        .call(d3.axisBottom(x).tickFormat(d3.format('d')));
+    svg.append('g')
+      .attr('transform', `translate(0,${height})`)
+      .call(d3.axisBottom(x).tickFormat(d3.format('d')));
 
-      const tooltip = d3.select('body')
-        .append('div')
-        .attr('class', 'tooltip')
-        .style('display', 'none');
+    const tooltip = d3.select('body')
+      .append('div')
+      .attr('class', 'tooltip')
+      .style('display', 'none');
 
-      svg.selectAll('circle')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('cx', d => x(d.year))
-        .attr('cy', height / 2)
-        .attr('r', 4)
-        .attr('fill', 'steelblue')
-        .on('mouseover', (event, d) => {
-          tooltip
-            .style('display', 'block')
-            .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
-            .style('left', (event.pageX + 5) + 'px')
-            .style('top', (event.pageY - 28) + 'px');
-        })
-        .on('mouseout', () => tooltip.style('display', 'none'));
-    });
+    svg.selectAll('circle')
+      .data(data)
+      .enter()
+      .append('circle')
+      .attr('cx', d => x(d.year))
+      .attr('cy', height / 2)
+      .attr('r', 4)
+      .attr('fill', 'steelblue')
+      .on('mouseover', (event, d) => {
+        tooltip
+          .style('display', 'block')
+          .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
+          .style('left', (event.pageX + 5) + 'px')
+          .style('top', (event.pageY - 28) + 'px');
+      })
+      .on('mouseout', () => tooltip.style('display', 'none'));
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -98,6 +98,8 @@
   </div>
   <div id="works"></div>
 
+  <script id="works-data" type="application/json" src="works.json"></script>
+
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o8NJD95AckS4iigFsMghvYDn8ApPhRHF9RSbuuZbQ2E=" crossorigin=""></script>
   <script>
     const categories = [
@@ -232,32 +234,36 @@
   }
 
     async function loadData() {
-      const works = await fetch('works.json').then(res => res.json());
+      const works = JSON.parse(document.getElementById('works-data').textContent);
       const files = ['Bacholoji.csv', 'Bachstiftung.csv', 'Netherlands_Bach_Society.csv'];
       const videoMap = {};
       for (const file of files) {
-        const buffer = await fetch(file).then(res => res.arrayBuffer());
-        const bytes = new Uint8Array(buffer);
-        let csv;
-        if (bytes[0] === 0xff && bytes[1] === 0xfe) {
-          csv = new TextDecoder('utf-16le').decode(bytes);
-        } else if (bytes[0] === 0xfe && bytes[1] === 0xff) {
-          csv = new TextDecoder('utf-16be').decode(bytes);
-        } else {
-          csv = new TextDecoder('utf-8').decode(bytes);
+        try {
+          const buffer = await fetch(file).then(res => res.arrayBuffer());
+          const bytes = new Uint8Array(buffer);
+          let csv;
+          if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+            csv = new TextDecoder('utf-16le').decode(bytes);
+          } else if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+            csv = new TextDecoder('utf-16be').decode(bytes);
+          } else {
+            csv = new TextDecoder('utf-8').decode(bytes);
+          }
+          csv.split(/\r?\n/).forEach(line => {
+            if (!line.trim()) return;
+            const [title, id, lengthStr] = line.split(';');
+            if (!title || !id) return;
+            const match = title.match(/BWV\s*(Anh\.\s*)?(\d+)/i);
+            if (!match) return;
+            const bwv = normalizeBwv(`${match[1] || ''}${match[2]}`);
+            const length = parseFloat(lengthStr) || 0;
+            const url = `https://youtu.be/${id.trim()}`;
+            if (!videoMap[bwv]) videoMap[bwv] = [];
+            videoMap[bwv].push({ url, length, file, title });
+          });
+        } catch (e) {
+          console.warn('Nie można wczytać pliku', file, e);
         }
-        csv.split(/\r?\n/).forEach(line => {
-          if (!line.trim()) return;
-          const [title, id, lengthStr] = line.split(';');
-          if (!title || !id) return;
-          const match = title.match(/BWV\s*(Anh\.\s*)?(\d+)/i);
-          if (!match) return;
-          const bwv = normalizeBwv(`${match[1] || ''}${match[2]}`);
-          const length = parseFloat(lengthStr) || 0;
-          const url = `https://youtu.be/${id.trim()}`;
-          if (!videoMap[bwv]) videoMap[bwv] = [];
-          videoMap[bwv].push({ url, length, file, title });
-        });
       }
       const container = document.getElementById('works');
       categories.forEach(cat => {


### PR DESCRIPTION
## Summary
- Load works.json directly via script tag and handle CSV loading errors to keep the map functional
- Replace timeline fetch with inline JSON script to render Bach's life timeline without network requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689673b63990832fa65d555b2a75bdb7