### PR TITLE
Fix Leaflet SRI hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dzieła Bacha – wszystkie utwory</title>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kG67wMPaG71mNVr3PVGQnuV+3fDXnJbmYsiDg=" crossorigin=""/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -97,7 +97,7 @@
     <label><input type="checkbox" data-col="10"> Video</label>
   </div>
   <div id="works"></div>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o8NJD95AckS4iigFsMghvYDn8ApPhRHF9RSbuuZbQ2E=" crossorigin=""></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script>
     const categories = [
       { name: 'Kantaty', start: 1, end: 224 },


### PR DESCRIPTION
## Summary
- update Leaflet CSS and JS links with correct SRI hashes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689770c117ac832f9aac6e7154b5242d