### PR TITLE
Reduce chart font size to 8px

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@ fetch('liturgical_year.json').then(r => r.json()).then(data => {
 
   const svg = d3.select('#chart')
       .attr('viewBox', [0, 0, width, width])
-      .style('font', '10px sans-serif');
+      .style('font', '8px sans-serif');
 
   const g = svg.append('g')
       .attr('transform', `translate(${width / 2},${width / 2})`);

--- a/liturgical_year.html
+++ b/liturgical_year.html
@@ -26,7 +26,7 @@ fetch('liturgical_year.json').then(r => r.json()).then(data => {
 
   const svg = d3.select('#chart')
       .attr('viewBox', [0, 0, width, width])
-      .style('font', '10px sans-serif');
+      .style('font', '8px sans-serif');
 
   const g = svg.append('g')
       .attr('transform', `translate(${width / 2},${width / 2})`);


### PR DESCRIPTION
## Summary
- Reduce D3 chart font from 10px to 8px for a more compact visualization.

## Testing
- `python -m py_compile build_liturgical_data.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897828151b4832f895e6b3187192f2b