### PR TITLE
Show liturgical event names on hover

### DIFF
--- a/liturgical_year.html
+++ b/liturgical_year.html
@@ -12,7 +12,34 @@ import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 const width = 932;
 const radius = width / 6;
 
-fetch('liturgical_year.json').then(r => r.json()).then(data => {
+Promise.all([
+  fetch('liturgical_year.json').then(r => r.json()),
+  fetch('works.json').then(r => r.json())
+]).then(([data, works]) => {
+  const worksMap = new Map(works.map(d => [d.BWV, d.Title]));
+
+  function getTitle(name) {
+    const match = name.match(/^BWV\s*(\d+)([a-z])?$/i);
+    if (!match) return '';
+    const num = match[1].padStart(4, '0');
+    const suffix = match[2] || '';
+    return worksMap.get(num + suffix) || '';
+  }
+
+  function tooltipText(d) {
+    if (d.children) {
+      const lines = [d.data.name];
+      d.leaves().forEach(leaf => {
+        const title = getTitle(leaf.data.name);
+        lines.push(`${leaf.data.name}${title ? ' – ' + title : ''}`);
+      });
+      return lines.join('\n');
+    } else {
+      const title = getTitle(d.data.name);
+      return `${d.data.name}${title ? ' – ' + title : ''}`;
+    }
+  }
+
   const color = d3.scaleOrdinal(d3.quantize(d3.interpolateRainbow, data.children.length + 1));
 
   const partition = data => d3.partition()
@@ -47,21 +74,12 @@ fetch('liturgical_year.json').then(r => r.json()).then(data => {
         .attr('fill-opacity', d => arcVisible(d.current) ? (d.children ? 0.6 : 0.4) : 0)
         .attr('d', d => arc(d.current));
 
+  path.append('title')
+      .text(d => tooltipText(d));
+
   path.filter(d => d.children)
       .style('cursor', 'pointer')
       .on('click', clicked);
-
-  const label = g.append('g')
-      .attr('pointer-events', 'none')
-      .attr('text-anchor', 'middle')
-      .style('user-select', 'none')
-    .selectAll('text')
-    .data(root.descendants().slice(1))
-    .join('text')
-      .attr('dy', '0.35em')
-      .attr('fill-opacity', d => +labelVisible(d.current))
-      .attr('transform', d => labelTransform(d.current))
-      .text(d => d.data.name);
 
   const parent = g.append('circle')
       .datum(root)
@@ -89,29 +107,10 @@ fetch('liturgical_year.json').then(r => r.json()).then(data => {
         })
       .attr('fill-opacity', d => arcVisible(d.target) ? (d.children ? 0.6 : 0.4) : 0)
       .attrTween('d', d => () => arc(d.current));
-
-    label.filter(d => labelVisible(d.target))
-        .transition(t)
-        .attr('fill-opacity', 1)
-        .attrTween('transform', d => () => labelTransform(d.current));
-
-    label.filter(d => !labelVisible(d.target))
-        .transition(t)
-        .attr('fill-opacity', 0);
   }
 
   function arcVisible(d) {
     return d.y1 <= radius && d.y0 >= 0 && d.x1 > d.x0;
-  }
-
-  function labelVisible(d) {
-    return d.y1 <= radius && d.y0 >= 0 && (d.x1 - d.x0) > 0.03;
-  }
-
-  function labelTransform(d) {
-    const x = (d.x0 + d.x1) / 2 * 180 / Math.PI;
-    const y = (d.y0 + d.y1) / 2;
-    return `rotate(${x - 90}) translate(${y},0) rotate(${x < 180 ? 0 : 180})`;
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- Load cantata titles and map them to BWV numbers
- Show liturgical event names and cantata titles only as hover tooltips

## Testing
- `python -m py_compile build_liturgical_data.py`


------
https://chatgpt.com/codex/tasks/task_e_689786336174832fb1799881dfa445f9