### PR TITLE
Improve Bach works chart sizing and tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,18 @@
     #chart {
       width: 100%;
       height: auto;
+      max-width: 600px;
+      display: block;
+      margin: 0 auto;
+    }
+    .tooltip {
+      position: absolute;
+      background: rgba(0, 0, 0, 0.7);
+      color: #fff;
+      padding: 5px;
+      border-radius: 4px;
+      pointer-events: none;
+      font-size: 12px;
     }
     @media (max-width: 600px) {
       body {
@@ -78,7 +90,7 @@
 <body>
   <h1>Dzieła Johanna Sebastiana Bacha</h1>
   <div id="map"></div>
-  <svg id="chart" width="932" height="932"></svg>
+  <svg id="chart" width="600" height="600"></svg>
   <div id="filters">
     Filtry:
     <label>Miasto:
@@ -346,14 +358,18 @@
 <script type="module">
 import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 
-const width = 932;
-const radius = width / 6;
+const width = 600;
+const radius = width / 2;
 
 Promise.all([
   fetch('liturgical_year.json').then(r => r.json()),
   fetch('works.json').then(r => r.json())
 ]).then(([data, works]) => {
   const worksMap = new Map(works.map(d => [d.BWV, d.Title]));
+  const tooltip = d3.select('body')
+    .append('div')
+    .attr('class', 'tooltip')
+    .style('opacity', 0);
 
   function getTitle(name) {
     const match = name.match(/^BWV\s*(\d+)([a-z])?$/i);
@@ -409,7 +425,14 @@ Promise.all([
       .join('path')
         .attr('fill', d => { while (d.depth > 1) d = d.parent; return color(d.data.name); })
         .attr('fill-opacity', d => arcVisible(d.current) ? (d.children ? 0.6 : 0.4) : 0)
-        .attr('d', d => arc(d.current));
+        .attr('d', d => arc(d.current))
+        .on('mousemove', (event, d) => {
+          tooltip.style('opacity', 1)
+                 .html(tooltipText(d).replace(/\n/g, '<br/>'))
+                 .style('left', (event.pageX + 10) + 'px')
+                 .style('top', (event.pageY + 10) + 'px');
+        })
+        .on('mouseout', () => tooltip.style('opacity', 0));
 
   path.append('title')
       .text(d => tooltipText(d));


### PR DESCRIPTION
## Summary
- Reduce chart SVG dimensions and limit max width for better layout
- Add custom tooltip that displays work information on hover

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_6897961a22d8832f850a8f96226c7361