### PR TITLE
Fix tooltip in Bach timeline by fetching data correctly

### DIFF
--- a/bach_timeline.html
+++ b/bach_timeline.html
@@ -28,49 +28,51 @@
 <body>
   <h1>Oś czasu życia Johanna Sebastiana Bacha</h1>
   <div id="timeline"></div>
-  <script id="timeline-data" type="application/json" src="timeline_data.json"></script>
   <script>
-    const data = JSON.parse(document.getElementById('timeline-data').textContent);
-    const margin = {top: 20, right: 20, bottom: 30, left: 40};
-    const width = 1000 - margin.left - margin.right;
-    const height = 200 - margin.top - margin.bottom;
+    fetch('timeline_data.json')
+      .then(response => response.json())
+      .then(data => {
+        const margin = {top: 20, right: 20, bottom: 30, left: 40};
+        const width = 1000 - margin.left - margin.right;
+        const height = 200 - margin.top - margin.bottom;
 
-    const svg = d3.select('#timeline')
-      .append('svg')
-      .attr('width', width + margin.left + margin.right)
-      .attr('height', height + margin.top + margin.bottom)
-      .append('g')
-      .attr('transform', `translate(${margin.left},${margin.top})`);
+        const svg = d3.select('#timeline')
+          .append('svg')
+          .attr('width', width + margin.left + margin.right)
+          .attr('height', height + margin.top + margin.bottom)
+          .append('g')
+          .attr('transform', `translate(${margin.left},${margin.top})`);
 
-    const x = d3.scaleLinear()
-      .domain(d3.extent(data, d => d.year))
-      .range([0, width]);
+        const x = d3.scaleLinear()
+          .domain(d3.extent(data, d => d.year))
+          .range([0, width]);
 
-    svg.append('g')
-      .attr('transform', `translate(0,${height})`)
-      .call(d3.axisBottom(x).tickFormat(d3.format('d')));
+        svg.append('g')
+          .attr('transform', `translate(0,${height})`)
+          .call(d3.axisBottom(x).tickFormat(d3.format('d')));
 
-    const tooltip = d3.select('body')
-      .append('div')
-      .attr('class', 'tooltip')
-      .style('display', 'none');
+        const tooltip = d3.select('body')
+          .append('div')
+          .attr('class', 'tooltip')
+          .style('display', 'none');
 
-    svg.selectAll('circle')
-      .data(data)
-      .enter()
-      .append('circle')
-      .attr('cx', d => x(d.year))
-      .attr('cy', height / 2)
-      .attr('r', 4)
-      .attr('fill', 'steelblue')
-      .on('mouseover', (event, d) => {
-        tooltip
-          .style('display', 'block')
-          .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
-          .style('left', (event.pageX + 5) + 'px')
-          .style('top', (event.pageY - 28) + 'px');
-      })
-      .on('mouseout', () => tooltip.style('display', 'none'));
+        svg.selectAll('circle')
+          .data(data)
+          .enter()
+          .append('circle')
+          .attr('cx', d => x(d.year))
+          .attr('cy', height / 2)
+          .attr('r', 4)
+          .attr('fill', 'steelblue')
+          .on('mouseover', (event, d) => {
+            tooltip
+              .style('display', 'block')
+              .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
+              .style('left', (event.pageX + 5) + 'px')
+              .style('top', (event.pageY - 28) + 'px');
+          })
+          .on('mouseout', () => tooltip.style('display', 'none'));
+      });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load `timeline_data.json` using `fetch` instead of a script tag so the timeline chart initializes properly.
- Ensure hover tooltips display event information for each year.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979efd8818832fbe984fff76eb73eb