### PR TITLE
Filter timeline to events with descriptions

### DIFF
--- a/bach_timeline.html
+++ b/bach_timeline.html
@@ -32,6 +32,8 @@
     fetch('timeline_data.json')
       .then(response => response.json())
       .then(data => {
+        const eventsData = data.filter(d => d.event && d.event.trim() !== '');
+
         const margin = {top: 20, right: 20, bottom: 30, left: 40};
         const width = 1000 - margin.left - margin.right;
         const height = 200 - margin.top - margin.bottom;
@@ -44,7 +46,7 @@
           .attr('transform', `translate(${margin.left},${margin.top})`);
 
         const x = d3.scaleLinear()
-          .domain(d3.extent(data, d => d.year))
+          .domain(d3.extent(eventsData, d => d.year))
           .range([0, width]);
 
         svg.append('g')
@@ -57,7 +59,7 @@
           .style('display', 'none');
 
         svg.selectAll('circle')
-          .data(data)
+          .data(eventsData)
           .enter()
           .append('circle')
           .attr('cx', d => x(d.year))
@@ -67,7 +69,7 @@
           .on('mouseover', (event, d) => {
             tooltip
               .style('display', 'block')
-              .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
+              .html(`<strong>${d.year}</strong>: ${d.event}`)
               .style('left', (event.pageX + 5) + 'px')
               .style('top', (event.pageY - 28) + 'px');
           })

--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
     fetch('timeline_data.json')
       .then(response => response.json())
       .then(data => {
+        const eventsData = data.filter(d => d.event && d.event.trim() !== '');
+
         const margin = {top: 20, right: 20, bottom: 30, left: 40};
         const width = 1000 - margin.left - margin.right;
         const height = 200 - margin.top - margin.bottom;
@@ -53,7 +55,7 @@
           .attr('transform', `translate(${margin.left},${margin.top})`);
 
         const x = d3.scaleLinear()
-          .domain(d3.extent(data, d => d.year))
+          .domain(d3.extent(eventsData, d => d.year))
           .range([0, width]);
 
         svg.append('g')
@@ -66,7 +68,7 @@
           .style('display', 'none');
 
         svg.selectAll('circle')
-          .data(data)
+          .data(eventsData)
           .enter()
           .append('circle')
           .attr('cx', d => x(d.year))
@@ -76,7 +78,7 @@
           .on('mouseover', (event, d) => {
             tooltip
               .style('display', 'block')
-              .html(`<strong>${d.year}</strong>: ${d.event || '(brak wydarzeń)'}`)
+              .html(`<strong>${d.year}</strong>: ${d.event}`)
               .style('left', (event.pageX + 5) + 'px')
               .style('top', (event.pageY - 28) + 'px');
           })


### PR DESCRIPTION
## Summary
- display timeline points only for entries with a non-empty `event` field in `index.html` and `bach_timeline.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ad811544832f92cd92db680521d6