### PR TITLE
Add AutoTranslate language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,15 @@
   <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
+  <div id="language-picker">
+    <label for="language-select">Język:</label>
+    <select id="language-select">
+      <option value="Polish">Polski</option>
+      <option value="English">English</option>
+      <option value="German">Deutsch</option>
+      <option value="French">Français</option>
+    </select>
+  </div>
   <h1>Dzieła Johanna Sebastiana Bacha</h1>
   <h2>Oś czasu życia Johanna Sebastiana Bacha</h2>
   <div id="timeline"></div>
@@ -87,6 +96,21 @@
   </script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script src="main.js"></script>
+  <script type="module">
+    import { autoTranslate } from "https://cdn.jsdelivr.net/gh/Mr-vero/AutoTranslate@v.1.0.3/dist/autoTranslate.js";
+    const sourceLang = "Polish";
+    const langMap = { Polish: "pl", English: "en", German: "de", French: "fr" };
+    const selector = document.getElementById('language-select');
+    async function applyTranslation() {
+      const target = selector.value;
+      document.documentElement.lang = langMap[target] || 'pl';
+      if (target !== sourceLang) {
+        await autoTranslate(sourceLang, target);
+      }
+    }
+    selector.addEventListener('change', applyTranslation);
+    document.addEventListener('dataLoaded', applyTranslation);
+  </script>
   <script type="module" src="chart.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -233,6 +233,7 @@
         updateColumnVisibility();
         applyFilters();
         createMap(cities);
+        document.dispatchEvent(new Event('dataLoaded'));
       }
 
   loadData().catch(err => console.error('Błąd wczytywania danych', err));


### PR DESCRIPTION
## Summary
- Add language dropdown and AutoTranslate integration to enable multilingual viewing
- Dispatch `dataLoaded` event after asynchronous content builds for translation updates

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2828f34832f891dd199e4e94f27