### PR TITLE
Translate timeline events to Polish

### DIFF
--- a/timeline_data.json
+++ b/timeline_data.json
@@ -50,13 +50,13 @@
   {
     "year": 1694,
     "age": "9",
-    "event": "Mother (50) dies, 1 May.",
+    "event": "Matka (50) umiera 1 maja.",
     "musicians": ""
   },
   {
     "year": 1695,
     "age": "10",
-    "event": "Father (49) dies, 20 Feb. Bach leaves Eisenach to live with brother, Johann Christoph (24), in Ohrdruf. Enters lyceum there.",
+    "event": "Ojciec (49) umiera 20 lutego. Bach opuszcza Eisenach, by zamieszkać z bratem, Johannem Christophem (24), w Ohrdruf i wstępuje do tamtejszego gimnazjum.",
     "musicians": "Locatelii born, 3 Sept. Purcell (36) dies, 21 Nov."
   },
   {
@@ -86,7 +86,7 @@
   {
     "year": 1700,
     "age": "15",
-    "event": "Leaves Ohrdruf for Lüneburg. Enrols in Michaelisschule there.",
+    "event": "Wyjeżdża z Ohrdruf do Lüneburga. Zapisuje się tam do Michaelisschule.",
     "musicians": "B.G. Sammartini born (or 1701)"
   },
   {
@@ -98,13 +98,13 @@
   {
     "year": 1702,
     "age": "17",
-    "event": "Applies unsuccessfully for organist's post at Jakobirche, Sangerhausen",
+    "event": "Bez powodzenia ubiega się o stanowisko organisty w Jakobikirche w Sangerhausen.",
     "musicians": ""
   },
   {
     "year": 1703,
     "age": "18",
-    "event": "Court musician at Weimar, March-Sept. Appointed organist at Neuekirche, Arnstadt, 9 Aug.",
+    "event": "Muzyk dworski w Weimarze od marca do września. 9 sierpnia mianowany organistą w Neuekirche w Arnstadt.",
     "musicians": "C.H. Graun born (or 1704) Harrer born, 8 May"
   },
   {
@@ -116,25 +116,25 @@
   {
     "year": 1705,
     "age": "20",
-    "event": "Granted 4 weeks leave of absence to visit Lübeck in ?Oct, but stays away longer.",
+    "event": "Otrzymuje czterotygodniowy urlop na odwiedzenie Lubeki w październiku (?), lecz pozostaje tam dłużej.",
     "musicians": ""
   },
   {
     "year": 1706,
     "age": "21",
-    "event": "Returns to Arnstadt, Jan/Feb. Appears before the consistory to answer for length of absence.",
+    "event": "Powraca do Arnstadt w styczniu/lutym. Staje przed konsystorzem, aby wytłumaczyć długość nieobecności.",
     "musicians": "Martini born, 24 April Pachelbel (52) buried, 9 March"
   },
   {
     "year": 1707,
     "age": "22",
-    "event": "Appointed organist at Blasiuskirche, Mühlhausen, 15 June. Marries Marie Barbara Bach (23) at Dornheim, 17 Oct.",
+    "event": "15 czerwca mianowany organistą w Blasiuskirche w Mühlhausen. 17 października poślubia Marie Barbarę Bach (23) w Dornheim.",
     "musicians": "Buxtehude (c.70) dies, 1 Oct."
   },
   {
     "year": 1708,
     "age": "23",
-    "event": "Appointed organist and chamber musician to Duke Wilhelm Ernst at Weimar, June. First child, Catharina Dorotheo, bapt. 29 Dec.",
+    "event": "W czerwcu mianowany organistą i muzykiem kameralnym księcia Wilhelma Ernsta w Weimarze. Pierwsze dziecko, Catharina Dorothea, ochrzczone 29 grudnia.",
     "musicians": "Blow (59) dies, 1 Oct."
   },
   {
@@ -146,7 +146,7 @@
   {
     "year": 1710,
     "age": "25",
-    "event": "Second child, Wilhelm Friedemann, born, 22 Nov.",
+    "event": "Drugie dziecko, Wilhelm Friedemann, urodzony 22 listopada.",
     "musicians": "Arne bapt., 28 May Pasquini (72) dies, 21 Nov. Pergolesi born, 4 Jan."
   },
   {
@@ -164,211 +164,211 @@
   {
     "year": 1713,
     "age": "28",
-    "event": "Visits Weissenfels, Feb. Third and fourth children (twins), Johann Christoph and Maria Sophia, born 23 Feb, and die, 23 Feb and c.13 March. Bach competes for organist's post at Halle, Dec.",
+    "event": "W lutym odwiedza Weißenfels. Trzecie i czwarte dziecko (bliźnięta), Johann Christoph i Maria Sophia, rodzą się 23 lutego i umierają: Johann Christoph 23 lutego, Maria Sophia około 13 marca. W grudniu Bach ubiega się o posadę organisty w Halle.",
     "musicians": "Corelli (59) dies, 8 Jan J.L. Krebs bapt., 12 Oct."
   },
   {
     "year": 1714,
     "age": "29",
-    "event": "Declines offer of Halle post, Feb, and is promoted to Konzertmeister at Weimar, 2 March. Fifth child, Carl Philipp Emanuel, born, 8 March.",
+    "event": "W lutym odmawia propozycji posady w Halle i 2 marca awansuje na koncertmistrza w Weimarze. Piąte dziecko, Carl Philipp Emanuel, urodzony 8 marca.",
     "musicians": "Gluck born, 2 July Jommelli born, 10 Sept."
   },
   {
     "year": 1715,
     "age": "30",
-    "event": "Sixth child, Johann Gottfried Berhard, born, 11 May.",
+    "event": "Szóste dziecko, Johann Gottfried Bernhard, urodzony 11 maja.",
     "musicians": "Doles born, 23 April Wagenseil born, 29 Jan."
   },
   {
     "year": 1716,
     "age": "31",
-    "event": "Examines new organs at Liebfrauenkirche, Halle, 29 April - 2 May, and Augustinerkirche, Erfurt, July.",
+    "event": "W dniach 29 kwietnia – 2 maja bada nowe organy w Liebfrauenkirche w Halle, a w lipcu w Augustinerkirche w Erfurcie.",
     "musicians": ""
   },
   {
     "year": 1717,
     "age": "32",
-    "event": "Appointed Kapellmeister to Prince Leopold at Cöthen, 5 Aug., but is at first prevented by Duke Wilhelm Ernst from taking up the post. Visits Dresden and accepts invitation to take part in contest with Marchand. Is imprisoned by Wilhelm Ernst, 6 Nov., but then allowed to leave Weimar, 2 Dec. Examines organ in Paulinerkirche, Leipzig, 16 Dec.",
+    "event": "5 sierpnia mianowany kapelmistrzem u księcia Leopolda w Köthen, lecz początkowo książę Wilhelm Ernst nie pozwala mu objąć stanowiska. Odwiedza Drezno i przyjmuje zaproszenie do udziału w pojedynku z Marchandem. 6 listopada zostaje uwięziony przez Wilhelma Ernsta, lecz 2 grudnia może opuścić Weimar. 16 grudnia bada organy w Paulinerkirche w Lipsku.",
     "musicians": "J. Stamitz bapt., 19 June."
   },
   {
     "year": 1718,
     "age": "33",
-    "event": "Visits Karlsbad with Prince Leopold, May-June. Seventh child, Leopold Augustus, born, 15 Nov.",
+    "event": "W maju–czerwcu odwiedza Karlsbad z księciem Leopoldem. Siódme dziecko, Leopold Augustus, urodzony 15 listopada.",
     "musicians": ""
   },
   {
     "year": 1719,
     "age": "34",
-    "event": "Death of son, Leopold Augustus (10 months); buried, 29 Sept.",
+    "event": "Śmierć syna, Leopolda Augusta (10 miesięcy); pochowany 29 września.",
     "musicians": "L. Mozart born, 14 Nov."
   },
   {
     "year": 1720,
     "age": "35",
-    "event": "Visits Karlsbad, May-July. Wife (35) dies; buried 7 July. Bach visits Hamburg, Nov., and is offered post as organist at the Jakobikirche, which he declines.",
+    "event": "W maju–lipcu odwiedza Karlsbad. Żona (35) umiera; pochowana 7 lipca. W listopadzie Bach odwiedza Hamburg i otrzymuje propozycję stanowiska organisty w Jakobikirche, którą odrzuca.",
     "musicians": "J.F. Agricola born, 4 Jan. Altnikol bapt., 1 Jan."
   },
   {
     "year": 1721,
     "age": "36",
-    "event": "Brandenburg Concertos dedicated to Margrave Christian Ludwig, 24 March. Marries Anna Magdalena Wilcke (20) at Cöthen, 3 Dec. Prince Leopold (27) marries Frederica Henrietta von Anhalt-Bernburg (19) at Bernburg, 11 Dec.",
+    "event": "Koncerty brandenburskie dedykowane margrabiemu Christianowi Ludwigowi, 24 marca. 3 grudnia w Köthen poślubia Annę Magdalenę Wilcke (20). 11 grudnia książę Leopold (27) poślubia Fredericę Henriettę von Anhalt-Bernburg (19) w Bernburgu.",
     "musicians": "Kirnberger born, 24 April."
   },
   {
     "year": 1722,
     "age": "37",
-    "event": "Brother, Johann Jacob (40) dies, 16 April. Bach enters candidature for cantorate at Leipzig, Dec.",
+    "event": "16 kwietnia umiera brat Johann Jacob (40). W grudniu Bach zgłasza kandydaturę na stanowisko kantora w Lipsku.",
     "musicians": "G. Benda bapt., 30 June Kuhnau (62) dies, 5 June Reincken (99) dies, 24 Nov."
   },
   {
     "year": 1723,
     "age": "38",
-    "event": "Eighth child, Christina Sophia Henrietta, born. Bach signs contract as Thomaskantor in Leipzig, 5 May. Arrives in Leipzig with family, 22 May. Cantata 75 performed in Nikolaikirche, 30 May. Exaines organ at Störmthal, Nov. Magnificat (BWV243a) performed in Thomaskirche, 25 Dec.",
+    "event": "Ósme dziecko, Christina Sophia Henrietta, urodzone. 5 maja Bach podpisuje kontrakt jako Thomaskantor w Lipsku. 22 maja przybywa z rodziną do Lipska. 30 maja w Nikolaikirche wykonana Kantata 75. W listopadzie bada organy w Störmthal. 25 grudnia w Thomaskirche wykonano Magnificat (BWV243a).",
     "musicians": "Gassmann born, 3 May."
   },
   {
     "year": 1724,
     "age": "39",
-    "event": "Ninth child, Gottfried Heinrich, born, 26 Feb. St. John Passion performed in Nikolaikirche, 7 April. Examines organ in Johanniskirche, Gera, 25 June.",
+    "event": "Dziewiąte dziecko, Gottfried Heinrich, urodzone 26 lutego. 7 kwietnia w Nikolaikirche wykonano Pasję według św. Jana. 25 czerwca bada organy w Johanniskirche w Gerze.",
     "musicians": ""
   },
   {
     "year": 1725,
     "age": "40",
-    "event": "Tenth child, Christian Gottlieb, bapt., 14 April. Bach gives organ recitals in Sophienirche, Dresden, 19-20 Sept. Visits Cöthen, 15 Dec.",
+    "event": "Dziesiąte dziecko, Christian Gottlieb, ochrzczone 14 kwietnia. 19–20 września Bach daje recitale organowe w Sophienkirche w Dreźnie. 15 grudnia odwiedza Köthen.",
     "musicians": "J.P. Krieger (75) dies, 6 Feb A. Scarlatti (65) dies, 22 Oct."
   },
   {
     "year": 1726,
     "age": "41",
-    "event": "Eleventh child, Elisabeth Juliana Friederika, bapt., 5 April. Daughter, Christiana Sophia Henrietta (3) dies, 29 June. Partita I (BWV 825) published, Michaelmas.",
+    "event": "Jedenaste dziecko, Elisabeth Juliana Friederika, ochrzczone 5 kwietnia. Córka Christiana Sophia Henrietta (3) umiera 29 czerwca. Partita I (BWV 825) opublikowana na święto św. Michała.",
     "musicians": "Lalande (68) dies, 18 June."
   },
   {
     "year": 1727,
     "age": "42",
-    "event": "St. Mathew Passion performed in Thomaskirche, 11 April (?). Trauer Ode (BWV 198) performed, 17 Oct, at memorial ceremony for Electress Christiane Eberhardine (died, 4 Sept.). Bach's twelfth child, Ernestus Andreas, bapt., 30 Oct. dies, 1 Nov.",
+    "event": "Pasja według św. Mateusza wykonana w Thomaskirche 11 kwietnia (?). Trauer Ode (BWV 198) wykonana 17 października podczas ceremonii żałobnej po elektorce Christiane Eberhardine (zmarłej 4 września). Dwunaste dziecko, Ernestus Andreas, ochrzczone 30 października, umiera 1 listopada.",
     "musicians": "Traetta born, 30 March."
   },
   {
     "year": 1728,
     "age": "43",
-    "event": "Son, Christian Gottlieb (3), dies, 21 Sept. Thirteenth child, Regina Johanna, bapt., 10 Oct. Prince Leopold of Anhalt-Cöthen (33) dies, 19 Nov. Bach's sister, Marie Salome Wiegand (née Bach) (51), dies in Erfurt, buried 27 Dec.",
+    "event": "Syn Christian Gottlieb (3) umiera 21 września. Trzynaste dziecko, Regina Johanna, ochrzczone 10 października. Książę Leopold von Anhalt-Köthen (33) umiera 19 listopada. Siostra Bacha, Marie Salome Wiegand (z domu Bach) (51), umiera w Erfurcie; pochowana 27 grudnia.",
     "musicians": "Piccinni born, 16 Jan Steffani (73) dies, 12 Feb."
   },
   {
     "year": 1729,
     "age": "44",
-    "event": "Bach visits Weissenfels, Feb. Visits Cöthen to perform funeral music for Prince Leopld, 23-4 March. St. Matthew Passion performed (for second? time) in Thomaskirche, 15 April. Disputes with council over admission of unmusical pupils to Thomasschule. Bach assumes direction of collegium musicum. Illness prevents his visiting Handel in Halle, June. Rektor of Thomasschule, J.H. Ernesti (77) dies, 16 Oct.",
+    "event": "Bach odwiedza Weißenfels w lutym. 23–24 marca jedzie do Köthen, by wykonać muzykę żałobną po księciu Leopoldzie. 15 kwietnia w Thomaskirche wykonana Pasja według św. Mateusza (po raz drugi?). Spór z radą o przyjmowanie niemuz ykalnych uczniów do Thomasschule. Bach obejmuje kierownictwo collegium musicum. Choroba uniemożliwia mu odwiedzenie Händla w Halle w czerwcu. 16 października umiera rektor Thomasschule, J.H. Ernesti (77).",
     "musicians": "Heinichen (46) dies, 16 July."
   },
   {
     "year": 1730,
     "age": "45",
-    "event": "Fourteenth child, Christiana Benedicta Louise, baptised, 1 Jan.; dies, 4 Jan.; Bach addresses memorandum on church music to town council, 23 Aug., and letter to Erdmann seeking possible employment in Gdansk, 28 Oct.. J.M. Gesner appointed Rektor of the Thomasschule, 8 Sept..",
+    "event": "Czternaste dziecko, Christiana Benedicta Louise, ochrzczone 1 stycznia; umiera 4 stycznia. 23 sierpnia Bach kieruje do rady miejskiej memorandum w sprawie muzyki kościelnej, a 28 października pisze do Erdmannna, szukając możliwego zatrudnienia w Gdańsku. 8 września J.M. Gesner zostaje mianowany rektorem Thomasschule.",
     "musicians": ""
   },
   {
     "year": 1731,
     "age": "46",
-    "event": "Clavier-Übung I (BWV825-30) published. Fifteenth child, Christiana Dorothea, baptised, 18 March. St Mark Passion performed in Thomaskirche, 23 March. Bach gives organ recitals in Dresden, 14-21 Sept. Examines organ at Stöntzsch, 12 Nov.",
+    "event": "Wydanie Clavier-Übung I (BWV825–830). Piętnaste dziecko, Christiana Dorothea, ochrzczone 18 marca. 23 marca w Thomaskirche wykonano Pasję według św. Marka. 14–21 września Bach daje recitale organowe w Dreźnie. 12 listopada bada organy w Stöntzsch.",
     "musicians": "Cannabich bapt., 28 Dec."
   },
   {
     "year": 1732,
     "age": "47",
-    "event": "Sixteenth child, Johann Christoph Friedrich, born 21 June. Daughter, Christiana Dorothea (1), dies, 31 Aug. Bach examines organ in Martinskirche, Kassel, 22-8 Sept.",
+    "event": "Szesnaste dziecko, Johann Christoph Friedrich, urodzony 21 czerwca. Córka Christiana Dorothea (1) umiera 31 sierpnia. 22–28 września Bach bada organy w Martinskirche w Kassel.",
     "musicians": "Haydn born, 31 March; Marchand (63) dies, 17 Feb."
   },
   {
     "year": 1733,
     "age": "48",
-    "event": "Daughter, Regina Johanna (4), dies 25 April. Son, Wilhelm Friedemann (23), appointed organist at Sophienkirche, Dresden, 23 June. Bach visits Dresden, July, and presents Missa (BWV232) to the Elector Friedrich August II. Seventeenth child, Johann August Abraham, bapt., 5 Nov; dies, 6 Nov.",
+    "event": "Córka Regina Johanna (4) umiera 25 kwietnia. Syn Wilhelm Friedemann (23) zostaje 23 czerwca organistą w Sophienkirche w Dreźnie. W lipcu Bach odwiedza Drezno i przedstawia Missa (BWV232) elektorowi Fryderykowi Augustowi II. Siedemnaste dziecko, Johann August Abraham, ochrzczone 5 listopada; umiera 6 listopada.",
     "musicians": "Böhm (71) dies, 18 May; Couperin (64) dies, 11 Sept."
   },
   {
     "year": 1734,
     "age": "49",
-    "event": "J.A. Ernesti (27) appointed Rektor of the Thomasschule. Christmas Oratorio , parts I-III performed 25, 26, 27 Dec.",
+    "event": "J.A. Ernesti (27) mianowany rektorem Thomasschule. Oratorium na Boże Narodzenie, części I–III, wykonane 25, 26 i 27 grudnia.",
     "musicians": "Gossec born, 17 Jan."
   },
   {
     "year": 1735,
     "age": "50",
-    "event": "Christmas Oratoria , parts IV-VI performed, 1, 2, 6 Jan. Clavier-Übung II (BWV971, 831) published, May. Bach examines organ in Marienkirche, Mülhausen, June, where his son Gottfried Bernhard (20) is appointed organist, 16 June. Bach's eighteenth child, Johann Christian, born, 5 Sept.",
+    "event": "Oratorium na Boże Narodzenie, części IV–VI, wykonane 1, 2 i 6 stycznia. W maju wydano Clavier-Übung II (BWV971, 831). W czerwcu Bach bada organy w Marienkirche w Mühlhausen, gdzie jego syn Gottfried Bernhard (20) zostaje 16 czerwca organistą. Osiemnaste dziecko, Johann Christian, urodzony 5 września.",
     "musicians": ""
   },
   {
     "year": 1736,
     "age": "51",
-    "event": "'Battle of the prefects' with Ernesti begins, July. Appointed Hofcompositeur to the Elector of Saxony, 19 Nov. Gives organ recital in Frauenkirche, Dresden, 1 Dec.",
+    "event": "\"Wojna prefektów\" z Ernesti rozpoczyna się w lipcu. 19 listopada mianowany kompozytorem dworskim elektora Saksonii. 1 grudnia daje recital organowy w Frauenkirche w Dreźnie.",
     "musicians": "Caldar (c.66) dies, 28 Dec; Pergolesi (26) dies, 16 March."
   },
   {
     "year": 1737,
     "age": "52",
-    "event": "Son, Johann Gottfried Bernhard (22), appointed organist at the Jakobikirche, Sangerhausen, 4 April. Bach temporarily relinquishes directorship of the collegium musicum, Spring. J.A. Schiebe publishes adverse criticism of Bach's music. Johann Elias Bach joins Bach's household as tutor and secretary, ?Oct. Nineteenth child, Johanna Carolina, bapt., 30 Oct.",
+    "event": "4 kwietnia syn Johann Gottfried Bernhard (22) zostaje organistą w Jakobikirche w Sangerhausen. Wiosną Bach czasowo rezygnuje z kierownictwa collegium musicum. J.A. Schiebe publikuje krytykę muzyki Bacha. Około października Johann Elias Bach dołącza do gospodarstwa jako nauczyciel i sekretarz. Dziewiętnaste dziecko, Johanna Carolina, ochrzczone 30 października.",
     "musicians": "Myslivecek born, 9 March."
   },
   {
     "year": 1738,
     "age": "53",
-    "event": "Son, Carl Philipp Emanuel (24), appointed harpsichordist to crown prince Frederick of Prussia. Bach visits Dresden, May. Son, Johann Gottfried Bernhard (23) contracts debts at Sangerhausen and absconds.",
+    "event": "Syn Carl Philipp Emanuel (24) zostaje klawesynistą następcy tronu Fryderyka Pruskiego. W maju Bach odwiedza Drezno. Syn Johann Gottfried Bernhard (23) zaciąga długi w Sangerhausen i ucieka.",
     "musicians": ""
   },
   {
     "year": 1739,
     "age": "54",
-    "event": "Son, Johann Gottfried Bernhard (24), dies, 27 May. Bach gives organ recital in the Schlosskirche, Altenburg. Clavier-Übung III published, Sept. Resumes as director of the collegium musicum, 2 Oct. Visits Weissenfels with Anna Magdalena, 7-14 Nov.",
+    "event": "27 maja umiera syn Johann Gottfried Bernhard (24). Bach daje recital organowy w Schlosskirche w Altenburgu. We wrześniu ukazuje się Clavier-Übung III. 2 października Bach ponownie obejmuje kierownictwo collegium musicum. 7–14 listopada odwiedza Weißenfels z Anną Magdaleną.",
     "musicians": "Dittersdorf born, 2 Nov.; Keiser (65) dies, 12 Sept; B. Marcello (52/53) dies, 24/25 July; Vanhal born, 12 May."
   },
   {
     "year": 1740,
     "age": "55",
-    "event": "Visits Halle, April.",
+    "event": "W kwietniu odwiedza Halle.",
     "musicians": "Paisiello born, 9 May."
   },
   {
     "year": 1741,
     "age": "56",
-    "event": "Visits son, Carl Philipp Emanuel, in Berlin, Aug. Anna Magdalena seriously ill. Bach visits Dresden, Nov. Clavier-Übung IV published (or 1742).",
+    "event": "W sierpniu odwiedza syna Carla Philippa Emanuela w Berlinie. Anna Magdalena poważnie chora. W listopadzie Bach odwiedza Drezno. Clavier-Übung IV opublikowana (lub w 1742).",
     "musicians": "Fux (c.80) dies, 13 Feb.; Grétry born, 8 Feb.; Vivaldi (63) dies, 28 July."
   },
   {
     "year": 1742,
     "age": "57",
-    "event": "Twentieth child, Regina Susanna, bapt., 22 Feb. Johann Elias Bach leaves Leipzig, 31 Oct.",
+    "event": "Dwudzieste dziecko, Regina Susanna, ochrzczone 22 lutego. 31 października Johann Elias Bach opuszcza Lipsk.",
     "musicians": ""
   },
   {
     "year": 1743,
     "age": "58",
-    "event": "Examines organ in Johanniskirche, Leipzig, Dec.",
+    "event": "W grudniu bada organy w Johanniskirche w Lipsku.",
     "musicians": "Boccherini born, 19 Feb."
   },
   {
     "year": 1744,
     "age": "59",
-    "event": "Son, Carl Philipp Emanuel (30), marries Johanna Maria Dannemann (20) in Berlin.",
+    "event": "Syn Carl Philipp Emanuel (30) poślubia Johannę Marię Dannemann (20) w Berlinie.",
     "musicians": ""
   },
   {
     "year": 1745,
     "age": "60",
-    "event": "First grandchild, Johann August Bach, born, 10 Dec.",
+    "event": "Pierwszy wnuk, Johann August Bach, urodzony 10 grudnia.",
     "musicians": "Zelenka (66) dies, 22 Dec."
   },
   {
     "year": 1746,
     "age": "61",
-    "event": "Son, Wilhelm Friedemann (36), appointed organist at the Liebfrauenkirche, Halle, 16 April. Bach examines organ in Wenselskirche, Naumburg, 27 Sept.",
+    "event": "Syn Wilhelm Friedemann (36) 16 kwietnia zostaje organistą w Liebfrauenkirche w Halle. 27 września Bach bada organy w Wenselskirche w Naumburgu.",
     "musicians": ""
   },
   {
     "year": 1747,
     "age": "62",
-    "event": "Visits court of Frederick the Great at Potsdam, 7-8 May, and gives organ recital in teh Heiliggeistkirche there, 8 May. Composes and published (Sept.) the Musical Offering . Joins Mizler's Society of Musical Sciences, June, for which he composes the Canonic Variations (BWV869).",
+    "event": "7–8 maja odwiedza dwór Fryderyka Wielkiego w Poczdamie i 8 maja daje recital organowy w tamtejszej Heiliggeistkirche. We wrześniu komponuje i publikuje Muzyczną ofiarę. W czerwcu wstępuje do Towarzystwa Nauk Muzycznych Mizlera, dla którego komponuje Wariacje kanoniczne (BWV869).",
     "musicians": "Bononcini (76) dies, 9 July."
   },
   {
@@ -380,13 +380,13 @@
   {
     "year": 1749,
     "age": "64",
-    "event": "Daughter, Elisabeth Juliana Frederica (23), marries Johann Christoph Altnikol (29) in Leipzig, 20 Jan. Harrer performs Probe in Leipzig, with a view to succeeding Bach as Thomaskantor, 8 June.",
+    "event": "Córka Elisabeth Juliana Frederica (23) poślubia Johanna Christopha Altnikola (29) w Lipsku 20 stycznia. 8 czerwca Harrer przeprowadza próbę w Lipsku z zamiarem objęcia po Bachu funkcji Thomaskantora.",
     "musicians": "Cimarosa born, 17 Dec."
   },
   {
     "year": 1750,
     "age": "65",
-    "event": "Son, Johann Christoph Friedrich (18), appointed court musician at Bückeburg, Jan. Bach occupied engraving the Art of Fugue . Operated on by oculist, John Taylor, March-April. Takes final communion, 22 July, and dies, 28 July. Buried in graveyard of the Johanniskirche, 31 July.",
+    "event": "Syn Johann Christoph Friedrich (18) w styczniu zostaje muzykiem dworskim w Bückeburgu. Bach zajmuje się grawerowaniem \"Sztuki fugi\". W marcu–kwietniu operowany przez okulistę Johna Taylora. 22 lipca przyjmuje ostatnią komunię i umiera 28 lipca. Pochowany na cmentarzu przy Johanniskirche 31 lipca.",
     "musicians": "A. Marcello (66) dies; Agricola aged 30; Albinoni 79; Altnikol 30; Arne 40; F. Benda 41; G. Benda 28; Boccherini 7; Boismortier 61; Boyce 39; Dittersdorf 11; Doles 35; Fasch 62; Gassmann 27; Geminiani 63; Gluck 36; Gossec 16; C.H. Graun c.47; Graupner 67; Grütry 9; Harrer 47; Hasse 51; Haydn 18; Jommelli 36; Kirnberger 29; J.L. Krebs 37; Leclair 53; Locatelli 55; Martini 44; L. Mozart 31; Myslivecek 13; Paisiello 10; Piccinni 22; Pisendel 63; Porpora 64; Quantz 53; Rameau 67; Sammartini c.50; J. Stamitz 33; Tartini 58; Telemann 69; Traetta 23; Vanhal 11; Wagenseil 35; Weiss 64 (dies)"
   }
 ]


### PR DESCRIPTION
## Summary
- Translate all timeline events to Polish for consistent localization.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897bef4b888832f940851c90c852359