### PR TITLE
Move inline scripts and styles out of index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
         <option value="">Wszystkie</option>
       </select>
     </label>
-    <label>Data od: <input type="number" id="date-from" style="width:6em"></label>
-    <label>do: <input type="number" id="date-to" style="width:6em"></label>
+    <label>Data od: <input type="number" id="date-from"></label>
+    <label>do: <input type="number" id="date-to"></label>
   </div>
   <div id="column-toggles">
     Pokaż kolumny:
@@ -46,71 +46,10 @@
     <label><input type="checkbox" data-col="10"> Video</label>
   </div>
   <div id="works"></div>
-  <script>
-    fetch('timeline_data.json')
-      .then(response => response.json())
-      .then(data => {
-        const eventsData = data.filter(d => d.event && d.event.trim() !== '');
-
-        const margin = {top: 20, right: 20, bottom: 30, left: 40};
-        const width = 1000 - margin.left - margin.right;
-        const height = 200 - margin.top - margin.bottom;
-
-        const svg = d3.select('#timeline')
-          .append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom)
-          .append('g')
-          .attr('transform', `translate(${margin.left},${margin.top})`);
-
-        const x = d3.scaleLinear()
-          .domain(d3.extent(eventsData, d => d.year))
-          .range([0, width]);
-
-        svg.append('g')
-          .attr('transform', `translate(0,${height})`)
-          .call(d3.axisBottom(x).tickFormat(d3.format('d')));
-
-        const tooltip = d3.select('body')
-          .append('div')
-          .attr('class', 'timeline-tooltip')
-          .style('display', 'none');
-
-        svg.selectAll('circle')
-          .data(eventsData)
-          .enter()
-          .append('circle')
-          .attr('cx', d => x(d.year))
-          .attr('cy', height / 2)
-          .attr('r', 4)
-          .attr('fill', 'steelblue')
-          .on('mouseover', (event, d) => {
-            tooltip
-              .style('display', 'block')
-              .html(`<strong>${d.year}</strong>: ${d.event}`)
-              .style('left', (event.pageX + 5) + 'px')
-              .style('top', (event.pageY - 28) + 'px');
-          })
-          .on('mouseout', () => tooltip.style('display', 'none'));
-      });
-  </script>
+    <script src="timeline.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script src="main.js"></script>
-  <script type="module">
-    import { autoTranslate } from "https://cdn.jsdelivr.net/gh/Mr-vero/AutoTranslate@v.1.0.3/dist/autoTranslate.js";
-    const sourceLang = "Polish";
-    const langMap = { Polish: "pl", English: "en", German: "de", French: "fr" };
-    const selector = document.getElementById('language-select');
-    async function applyTranslation() {
-      const target = selector.value;
-      document.documentElement.lang = langMap[target] || 'pl';
-      if (target !== sourceLang) {
-        await autoTranslate(sourceLang, target);
-      }
-    }
-    selector.addEventListener('change', applyTranslation);
-    document.addEventListener('dataLoaded', applyTranslation);
-  </script>
+    <script type="module" src="translate.js"></script>
   <script type="module" src="chart.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,9 @@ tr:nth-child(even) {
 #filters label {
   margin-right: 10px;
 }
+#filters input[type="number"] {
+  width: 6em;
+}
 #chart {
   width: 100%;
   height: auto;

--- a/timeline.js
+++ b/timeline.js
@@ -1,0 +1,46 @@
+fetch('timeline_data.json')
+  .then(response => response.json())
+  .then(data => {
+    const eventsData = data.filter(d => d.event && d.event.trim() !== '');
+
+    const margin = {top: 20, right: 20, bottom: 30, left: 40};
+    const width = 1000 - margin.left - margin.right;
+    const height = 200 - margin.top - margin.bottom;
+
+    const svg = d3.select('#timeline')
+      .append('svg')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+      .attr('transform', `translate(${margin.left},${margin.top})`);
+
+    const x = d3.scaleLinear()
+      .domain(d3.extent(eventsData, d => d.year))
+      .range([0, width]);
+
+    svg.append('g')
+      .attr('transform', `translate(0,${height})`)
+      .call(d3.axisBottom(x).tickFormat(d3.format('d')));
+
+    const tooltip = d3.select('body')
+      .append('div')
+      .attr('class', 'timeline-tooltip')
+      .style('display', 'none');
+
+    svg.selectAll('circle')
+      .data(eventsData)
+      .enter()
+      .append('circle')
+      .attr('cx', d => x(d.year))
+      .attr('cy', height / 2)
+      .attr('r', 4)
+      .attr('fill', 'steelblue')
+      .on('mouseover', (event, d) => {
+        tooltip
+          .style('display', 'block')
+          .html(`<strong>${d.year}</strong>: ${d.event}`)
+          .style('left', (event.pageX + 5) + 'px')
+          .style('top', (event.pageY - 28) + 'px');
+      })
+      .on('mouseout', () => tooltip.style('display', 'none'));
+  });

--- a/translate.js
+++ b/translate.js
@@ -1,0 +1,13 @@
+import { autoTranslate } from "https://cdn.jsdelivr.net/gh/Mr-vero/AutoTranslate@v.1.0.3/dist/autoTranslate.js";
+const sourceLang = "Polish";
+const langMap = { Polish: "pl", English: "en", German: "de", French: "fr" };
+const selector = document.getElementById('language-select');
+async function applyTranslation() {
+  const target = selector.value;
+  document.documentElement.lang = langMap[target] || 'pl';
+  if (target !== sourceLang) {
+    await autoTranslate(sourceLang, target);
+  }
+}
+selector.addEventListener('change', applyTranslation);
+document.addEventListener('dataLoaded', applyTranslation);


### PR DESCRIPTION
## Summary
- Extract timeline rendering script into new `timeline.js`
- Extract language auto-translation script into new `translate.js`
- Replace inline styles for date inputs with CSS rule in `styles.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68988835d7dc832f98543df7bcc8714d