### PR TITLE
fix: show labels for small chart segments

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -142,7 +142,7 @@ Promise.all([
   }
 
   function labelVisible(d) {
-    return d.y1 <= radius && d.y0 >= 0 && d.x1 > d.x0 && (d.y1 - d.y0) * (d.x1 - d.x0) > 0.03;
+    return d.y1 <= radius && d.y0 >= 0 && d.x1 > d.x0 && (d.y1 - d.y0) * (d.x1 - d.x0) > 0.002;
   }
 
   function labelTransform(d) {


### PR DESCRIPTION
## Summary
- ensure small segments display their labels by lowering visibility threshold

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b506e42c832fbb0219716bb30b2b