### PR TITLE
Add Germany map alongside chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,10 @@
   <h1>Dzieła Johanna Sebastiana Bacha</h1>
   <h2>Oś czasu życia Johanna Sebastiana Bacha</h2>
   <div id="timeline"></div>
-  <div id="map"></div>
-  <svg id="chart" width="600" height="600"></svg>
+  <div id="visualizations">
+    <div id="map"></div>
+    <svg id="chart" width="600" height="600"></svg>
+  </div>
   <div id="filters">
     Filtry:
     <label>Miasto:

--- a/main.js
+++ b/main.js
@@ -119,9 +119,15 @@
       'Ohrdruf': { coords: [50.82, 10.729], years: '1695–1700' },
       'Weimar': { coords: [50.979, 11.329], years: '1708–1717' }
     };
-    const map = L.map('map').setView([51.1657, 10.4515], 6);
+    const bounds = [[47.2701, 5.8663], [55.0581, 15.0419]];
+    const map = L.map('map', {
+      maxBounds: bounds,
+      maxBoundsViscosity: 1.0,
+      minZoom: 6
+    }).fitBounds(bounds);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '\u00a9 OpenStreetMap'
+      attribution: '\u00a9 OpenStreetMap',
+      noWrap: true
     }).addTo(map);
     cities.forEach(city => {
       const info = cityInfo[city];

--- a/styles.css
+++ b/styles.css
@@ -39,9 +39,17 @@ tr:nth-child(even) {
 #column-toggles label {
   margin-right: 10px;
 }
+#visualizations {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin: 20px 0;
+}
+
 #map {
   height: 400px;
-  margin: 20px 0;
+  flex: 1 1 600px;
 }
 #filters {
   margin: 10px 0;
@@ -56,8 +64,8 @@ tr:nth-child(even) {
   width: 100%;
   height: auto;
   max-width: 600px;
-  display: block;
-  margin: 0 auto;
+  flex: 1 1 600px;
+  margin: 0;
 }
 .tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- Display map and chart side by side using a new flex container
- Restrict map view to Germany with bounding box limits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c4662cf0832f90844d1fbe480bcc