### PR TITLE
Limit map width and hide outer chart labels

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -123,7 +123,7 @@ Promise.all([
       .attr('text-anchor', 'middle')
       .style('user-select', 'none')
       .selectAll('text')
-      .data(root.descendants().slice(1))
+      .data(root.descendants().slice(1).filter(d => d.children))
       .join('text')
         .attr('dy', '0.35em');
 
@@ -187,7 +187,7 @@ Promise.all([
   }
 
   function labelVisible(d) {
-    return d.y1 <= 3 && d.y0 >= 1 && (d.y1 - d.y0) * (d.x1 - d.x0) > 0.03;
+    return d.children && d.y1 <= 3 && d.y0 >= 1 && (d.y1 - d.y0) * (d.x1 - d.x0) > 0.03;
   }
 
   function labelTransform(d) {

--- a/styles.css
+++ b/styles.css
@@ -49,7 +49,8 @@ tr:nth-child(even) {
 
 #map {
   height: 400px;
-  flex: 1 1 600px;
+  flex: 0 0 50%;
+  max-width: 50%;
 }
 #filters {
   margin: 10px 0;


### PR DESCRIPTION
## Summary
- Reduce map container to half the page width for balanced layout
- Hide labels on outer chart segments, showing titles only on hover via tooltip

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c875e7b4832f9bf41643ed79cfc4