### PR TITLE
Display leaf names only in tooltip for liturgical year chart

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -121,7 +121,7 @@ Promise.all([
       .attr('text-anchor', 'middle')
       .style('user-select', 'none')
       .selectAll('text')
-      .data(root.descendants().slice(1))
+      .data(root.descendants().slice(1).filter(d => d.children))
       .join('text')
         .attr('dy', '0.35em');
 


### PR DESCRIPTION
## Summary
- Hide labels for leaf nodes so events are visible only via tooltip

## Testing
- `node --check chart.js`


------
https://chatgpt.com/codex/tasks/task_e_68990b3724a0832f83db91eb7bfb3f0f