### PR TITLE
Hide intermediate labels from sunburst chart

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -121,7 +121,7 @@ Promise.all([
       .attr('text-anchor', 'middle')
       .style('user-select', 'none')
       .selectAll('text')
-      .data(root.descendants().slice(1).filter(d => d.children))
+      .data(root.descendants().slice(1).filter(d => d.children && d.depth === 1))
       .join('text')
         .attr('dy', '0.35em');
 


### PR DESCRIPTION
## Summary
- Show only top-level labels in the liturgical year sunburst chart so intermediate nodes like individual Sundays appear only in tooltips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990fcc8e1c832f9e606e14ede07d7f