### PR TITLE
Remove fixed SVG dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
           <div id="map"></div>
         </div>
         <div class="column is-half">
-          <svg id="chart" width="600" height="600"></svg>
+          <svg id="chart"></svg>
         </div>
       </div>
 

--- a/liturgical_year.html
+++ b/liturgical_year.html
@@ -14,7 +14,7 @@ svg { width: 100%; height: auto; }
   font-size: 12px;
 }
 </style>
-<svg id="chart" width="932" height="932"></svg>
+<svg id="chart"></svg>
 <script type="module">
 import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 


### PR DESCRIPTION
## Summary
- Remove hard-coded width and height from chart SVG in index and liturgical year pages to allow CSS-based sizing.

## Testing
- `python -m py_compile build_liturgical_data.py`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1d5d8fc832f8a1be4ed770af24b